### PR TITLE
fix: add noindex to /blog/best-home-office-paint-colors

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -23,9 +23,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const post = getPostBySlug(slug);
   if (!post) return { title: "Post Not Found" };
   const url = `https://www.paintcolorhq.com/blog/${post.slug}`;
+  // Noindex pages pending content rewrite (CAM-65)
+  const noindexSlugs = new Set(["best-home-office-paint-colors"]);
+
   return {
     title: `${post.title} | Paint Color HQ`,
     description: post.excerpt,
+    ...(noindexSlugs.has(slug) && { robots: { index: false, follow: true } }),
     alternates: { canonical: url },
     openGraph: {
       title: post.title, description: post.excerpt, type: "article",


### PR DESCRIPTION
## Summary
- Adds `robots: { index: false, follow: true }` to `/blog/best-home-office-paint-colors` via `generateMetadata`
- Uses a `noindexSlugs` Set for easy future additions/removals
- Temporary measure while the post is rewritten with human content

## Context
- Part of PaintColorHQ SEO recovery (CAM-64 / CAM-58)
- This post has the strongest AI writing signals across all 27 blog posts

## Test plan
- [ ] Verify `/blog/best-home-office-paint-colors` returns `<meta name="robots" content="noindex, follow">` in page source
- [ ] Verify other blog posts are unaffected (no robots meta override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)