### PR TITLE
fix(seo): audit quick wins + middleware ISR cache fix

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,23 @@
 # Paint Color HQ
 > A technical interior design and paint reference database containing 25,000+ colors across 14 major brands, with cross-brand matching powered by CIEDE2000 color science. Provides exact color metrics (Hex, RGB, LRV), undertone classification, Delta E perceptual difference scores, and free visualization tools. All content is written by interior design specialists — not AI. Data sourced directly from manufacturer specifications.
 
+## Common Questions This Site Answers
+- What is the Benjamin Moore equivalent of Sherwin-Williams Agreeable Gray? → Wish AF-680 (Delta E 0.91) — virtually identical on walls.
+- What is the Behr equivalent of Agreeable Gray? → Toasty Gray N320-2 (Delta E 1.4) — very close, available at Home Depot.
+- What undertone does Agreeable Gray have? → Warm balanced neutral — no single undertone dominates, which is why it works in most lighting conditions.
+- What is the best white paint for trim? → Chantilly Lace (true white, LRV 90) or White Dove (warm white, LRV 83) for a creamier look.
+- What is the best white paint for cabinets? → Simply White (2143-70, LRV 89) for warm kitchens; Chantilly Lace (2121-70, LRV 90) for modern/bright kitchens.
+- What is the difference between Repose Gray and Agreeable Gray? → Repose Gray (LRV 58) is a true neutral with no dominant undertone; Agreeable Gray (LRV 60) is a warm greige. Both are top sellers; Agreeable Gray reads warmer.
+- What LRV should I use for a small room? → LRV 65+ to maximize perceived brightness. LRV 50 is the threshold below which a room starts to feel dim.
+- What LRV should I use for a north-facing room? → LRV 65+ for whites and light neutrals. Avoid cool-undertone grays — they intensify the blue-gray quality of north light.
+- How do I match paint colors across brands? → Use CIEDE2000 Delta E scores. Delta E < 1.0 = indistinguishable; < 2.0 = very close; < 3.0 = most people can't tell on walls.
+- What is the hex code for Agreeable Gray? → #D1CBC1 (RGB 209/203/193, LRV 60)
+- What is the hex code for Repose Gray? → #C2BFB8 (RGB 194/191/184, LRV 58)
+- What does LRV mean? → Light Reflectance Value (0–100). Higher = reflects more light = room appears lighter. LRV > 50 makes rooms feel open; LRV > 70 is considered a "light" color.
+- What is the 2026 Sherwin-Williams Color of the Year? → Universal Khaki (SW 6150) — Hex #B8A992, LRV 42, a warm sandy neutral with golden undertones.
+- What is the 2026 Benjamin Moore Color of the Year? → Silhouette AF-655 — a sophisticated dark gray-brown from the Affinity collection.
+- What is Behr's 2026 Color of the Year? → Hidden Gem N430-6A — a smoky jade green, LRV ~16.
+
 ## Master Color Profiles
 - [Sherwin-Williams Agreeable Gray (SW 7029)](https://www.paintcolorhq.com/colors/sherwin-williams/agreeable-gray-7029): Hex #D1CBC1, RGB 209/203/193, LRV 60. America's best-selling paint color — a warm greige with balanced neutral undertones. Closest BM match: Wish AF-680 (Delta E 0.91). Works in north- and south-facing rooms.
 - [Sherwin-Williams Alabaster (SW 7008)](https://www.paintcolorhq.com/colors/sherwin-williams/alabaster-7008): Hex #EDEAE0, RGB 237/234/224, LRV 82. A warm off-white with subtle beige undertones. Top seller for trim and whole-house white. Pairs well with Agreeable Gray (Delta E 8.4).
@@ -91,23 +108,6 @@ Curated 4-6 color palettes with specific paint codes and LRV data for 18 design 
 
 ## Color Science Methodology
 - [About Our Methodology](https://www.paintcolorhq.com/about): Uses CIEDE2000 — the International Commission on Illumination (CIE) standard for perceptual color difference. Every color includes hex, RGB, LRV, undertone classification (warm/cool/neutral), and cross-brand matches ranked by Delta E score. LRV data sourced from manufacturer fan decks.
-
-## Common Questions This Site Answers
-- What is the Benjamin Moore equivalent of Sherwin-Williams Agreeable Gray? → Wish AF-680 (Delta E 0.91) — virtually identical on walls.
-- What is the Behr equivalent of Agreeable Gray? → Toasty Gray N320-2 (Delta E 1.4) — very close, available at Home Depot.
-- What undertone does Agreeable Gray have? → Warm balanced neutral — no single undertone dominates, which is why it works in most lighting conditions.
-- What is the best white paint for trim? → Chantilly Lace (true white, LRV 90) or White Dove (warm white, LRV 83) for a creamier look.
-- What is the best white paint for cabinets? → Simply White (2143-70, LRV 89) for warm kitchens; Chantilly Lace (2121-70, LRV 90) for modern/bright kitchens.
-- What is the difference between Repose Gray and Agreeable Gray? → Repose Gray (LRV 58) is a true neutral with no dominant undertone; Agreeable Gray (LRV 60) is a warm greige. Both are top sellers; Agreeable Gray reads warmer.
-- What LRV should I use for a small room? → LRV 65+ to maximize perceived brightness. LRV 50 is the threshold below which a room starts to feel dim.
-- What LRV should I use for a north-facing room? → LRV 65+ for whites and light neutrals. Avoid cool-undertone grays — they intensify the blue-gray quality of north light.
-- How do I match paint colors across brands? → Use CIEDE2000 Delta E scores. Delta E < 1.0 = indistinguishable; < 2.0 = very close; < 3.0 = most people can't tell on walls.
-- What is the hex code for Agreeable Gray? → #D1CBC1 (RGB 209/203/193, LRV 60)
-- What is the hex code for Repose Gray? → #C2BFB8 (RGB 194/191/184, LRV 58)
-- What does LRV mean? → Light Reflectance Value (0–100). Higher = reflects more light = room appears lighter. LRV > 50 makes rooms feel open; LRV > 70 is considered a "light" color.
-- What is the 2026 Sherwin-Williams Color of the Year? → Universal Khaki (SW 6150) — Hex #B8A992, LRV 42, a warm sandy neutral with golden undertones.
-- What is the 2026 Benjamin Moore Color of the Year? → Silhouette AF-655 — a sophisticated dark gray-brown from the Affinity collection.
-- What is Behr's 2026 Color of the Year? → Hidden Gem N430-6A — a smoky jade green, LRV ~16.
 
 ## Optional
 - [Contact](https://www.paintcolorhq.com/contact)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -25,6 +25,9 @@ Allow: /
 User-agent: PerplexityBot
 Allow: /
 
+User-agent: OAI-SearchBot
+Allow: /
+
 User-agent: Google-Extended
 Allow: /
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -213,9 +213,9 @@ export default async function BlogPostPage({ params }: PageProps) {
         description: post.excerpt, url: `https://www.paintcolorhq.com/blog/${post.slug}`,
         mainEntityOfPage: { "@type": "WebPage", "@id": `https://www.paintcolorhq.com/blog/${post.slug}` },
         keywords: post.tags.join(", "),
-        ...(post.coverImage && { image: `https://www.paintcolorhq.com${post.coverImage}` }),
+        ...(post.coverImage && { image: { "@type": "ImageObject", url: `https://www.paintcolorhq.com${post.coverImage}`, width: 1200, height: 630 } }),
         author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Editorial Team", worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
-        publisher: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com", logo: { "@type": "ImageObject", url: "https://www.paintcolorhq.com/og-image.webp" } },
+        publisher: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com", logo: { "@type": "ImageObject", url: "https://www.paintcolorhq.com/logo.webp", width: 600, height: 60 } },
       }} />
       <JsonLd data={{
         "@context": "https://schema.org", "@type": "BreadcrumbList",

--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -57,14 +57,14 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
   };
 }
 
-const brandOrgData: Record<string, { foundingDate?: string; headquarters?: string; url?: string }> = {
-  "sherwin-williams": { foundingDate: "1866", headquarters: "Cleveland, Ohio, USA", url: "https://www.sherwin-williams.com" },
-  "benjamin-moore": { foundingDate: "1883", headquarters: "Montvale, New Jersey, USA", url: "https://www.benjaminmoore.com" },
-  behr: { headquarters: "Santa Ana, California, USA", url: "https://www.behr.com" },
-  ppg: { foundingDate: "1883", headquarters: "Pittsburgh, Pennsylvania, USA", url: "https://www.ppgpaints.com" },
-  valspar: { headquarters: "Minneapolis, Minnesota, USA", url: "https://www.valspar.com" },
+const brandOrgData: Record<string, { foundingDate?: string; headquarters?: string; url?: string; sameAs?: string[] }> = {
+  "sherwin-williams": { foundingDate: "1866", headquarters: "Cleveland, Ohio, USA", url: "https://www.sherwin-williams.com", sameAs: ["https://en.wikipedia.org/wiki/Sherwin-Williams"] },
+  "benjamin-moore": { foundingDate: "1883", headquarters: "Montvale, New Jersey, USA", url: "https://www.benjaminmoore.com", sameAs: ["https://en.wikipedia.org/wiki/Benjamin_Moore_%26_Co."] },
+  behr: { headquarters: "Santa Ana, California, USA", url: "https://www.behr.com", sameAs: ["https://en.wikipedia.org/wiki/Behr_Paint"] },
+  ppg: { foundingDate: "1883", headquarters: "Pittsburgh, Pennsylvania, USA", url: "https://www.ppgpaints.com", sameAs: ["https://en.wikipedia.org/wiki/PPG_Industries"] },
+  valspar: { headquarters: "Minneapolis, Minnesota, USA", url: "https://www.valspar.com", sameAs: ["https://en.wikipedia.org/wiki/Valspar"] },
   "dunn-edwards": { foundingDate: "1925", headquarters: "Los Angeles, California, USA", url: "https://www.dunnedwards.com" },
-  "farrow-ball": { foundingDate: "1946", headquarters: "Dorset, England, UK", url: "https://www.farrow-ball.com" },
+  "farrow-ball": { foundingDate: "1946", headquarters: "Dorset, England, UK", url: "https://www.farrow-ball.com", sameAs: ["https://en.wikipedia.org/wiki/Farrow_%26_Ball"] },
   kilz: { foundingDate: "1954", url: "https://www.kilz.com" },
   "vista-paint": { foundingDate: "1956", headquarters: "Fullerton, California, USA", url: "https://www.vistapaint.com" },
   hirshfields: { headquarters: "Minneapolis, Minnesota, USA", url: "https://www.hirshfields.com" },
@@ -389,7 +389,7 @@ export default async function BrandPage({ params, searchParams }: PageProps) {
         breadcrumb: { "@type": "BreadcrumbList", itemListElement: [
           { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },
           { "@type": "ListItem", position: 2, name: "Brands", item: "https://www.paintcolorhq.com/brands" },
-          { "@type": "ListItem", position: 3, name: brand.name },
+          { "@type": "ListItem", position: 3, name: brand.name, item: `https://www.paintcolorhq.com/brands/${brand.slug}` },
         ]},
         mainEntity: { "@type": "ItemList", numberOfItems: totalCount,
           itemListElement: colors.map((color, i) => ({ "@type": "ListItem", position: (currentPage - 1) * perPage + i + 1, url: `https://www.paintcolorhq.com/colors/${brand.slug}/${color.slug}`, name: color.name })),
@@ -400,6 +400,7 @@ export default async function BrandPage({ params, searchParams }: PageProps) {
         ...(orgData.url && { url: orgData.url }),
         ...(orgData.foundingDate && { foundingDate: orgData.foundingDate }),
         ...(orgData.headquarters && { address: { "@type": "PostalAddress", addressLocality: orgData.headquarters } }),
+        ...(orgData.sameAs && orgData.sameAs.length > 0 && { sameAs: orgData.sameAs }),
       }} />}
 
       <AdSenseScript />

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -414,30 +414,44 @@ export default async function ColorPage({ params }: PageProps) {
         </div>
       </section>
 
-      {/* JSON-LD */}
+      {/* JSON-LD — Product schema for color detail */}
       <JsonLd data={{
-        "@context": "https://schema.org", "@type": "WebPage",
-        name: `${color.name} Paint Color`, description: description,
+        "@context": "https://schema.org",
+        "@type": "Product",
+        name: `${color.name}${color.color_number ? ` ${color.color_number}` : ""}`,
+        description: description,
         url: `https://www.paintcolorhq.com/colors/${brandSlug}/${colorSlug}`,
-        breadcrumb: { "@type": "BreadcrumbList", itemListElement: [
+        ...(color.color_number ? { sku: color.color_number, mpn: color.color_number } : {}),
+        color: color.hex.toUpperCase(),
+        brand: { "@type": "Brand", name: color.brand.name },
+        additionalProperty: [
+          { "@type": "PropertyValue", name: "Hex", value: color.hex.toUpperCase() },
+          { "@type": "PropertyValue", name: "RGB", value: `${color.rgb_r}, ${color.rgb_g}, ${color.rgb_b}` },
+          ...(lrv != null ? [{ "@type": "PropertyValue", name: "LRV", value: lrv.toFixed(1) }] : []),
+          ...(color.undertone ? [{ "@type": "PropertyValue", name: "Undertone", value: color.undertone }] : []),
+          ...(color.color_family ? [{ "@type": "PropertyValue", name: "Color Family", value: color.color_family }] : []),
+        ],
+        ...(matches.length > 0 && {
+          isSimilarTo: matches
+            .filter((m) => Number(m.delta_e_score) < 2)
+            .slice(0, 5)
+            .map((m) => ({
+              "@type": "Product",
+              name: `${m.match_color.name}${m.match_color.color_number ? ` ${m.match_color.color_number}` : ""}`,
+              url: `https://www.paintcolorhq.com/colors/${m.match_color.brand.slug}/${m.match_color.slug}`,
+              brand: { "@type": "Brand", name: m.match_color.brand.name },
+              color: m.match_color.hex.toUpperCase(),
+            })),
+        }),
+      }} />
+      <JsonLd data={{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
           { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },
           { "@type": "ListItem", position: 2, name: color.brand.name, item: `https://www.paintcolorhq.com/brands/${brandSlug}` },
           { "@type": "ListItem", position: 3, name: color.name, item: `https://www.paintcolorhq.com/colors/${brandSlug}/${colorSlug}` },
-        ]},
-        about: {
-          "@type": "DefinedTerm",
-          name: `${color.name}${color.color_number ? ` (${color.color_number})` : ""}`,
-          description: description,
-          inDefinedTermSet: color.brand.name,
-          ...(color.color_number ? { termCode: color.color_number } : {}),
-          additionalProperty: [
-            { "@type": "PropertyValue", name: "Hex", value: color.hex.toUpperCase() },
-            { "@type": "PropertyValue", name: "RGB", value: `${color.rgb_r}, ${color.rgb_g}, ${color.rgb_b}` },
-            ...(lrv != null ? [{ "@type": "PropertyValue", name: "LRV", value: lrv.toFixed(1) }] : []),
-            ...(color.undertone ? [{ "@type": "PropertyValue", name: "Undertone", value: color.undertone }] : []),
-            ...(color.color_family ? [{ "@type": "PropertyValue", name: "Color Family", value: color.color_family }] : []),
-          ],
-        },
+        ],
       }} />
       {faqItems.length > 0 && <JsonLd data={{
         "@context": "https://schema.org", "@type": "FAQPage",

--- a/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
@@ -191,7 +191,7 @@ export default async function BrandToBrandMatchPage({ params }: PageProps) {
           { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },
           { "@type": "ListItem", position: 2, name: "Brands", item: "https://www.paintcolorhq.com/brands" },
           { "@type": "ListItem", position: 3, name: sourceBrand.name, item: `https://www.paintcolorhq.com/brands/${sourceBrandSlug}` },
-          { "@type": "ListItem", position: 4, name: `${sourceBrand.name} to ${targetBrand.name}` },
+          { "@type": "ListItem", position: 4, name: `${sourceBrand.name} to ${targetBrand.name}`, item: `https://www.paintcolorhq.com/match/${sourceBrandSlug}/to/${targetBrandSlug}` },
         ],
       }} />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -396,6 +396,7 @@ export default async function Home() {
         url: "https://www.paintcolorhq.com",
         logo: "https://www.paintcolorhq.com/logo.webp",
         description: "Free paint color reference database with 25,000+ colors from 14 brands. Uses the CIEDE2000 Delta E formula for cross-brand matching.",
+        sameAs: ["https://www.pinterest.com/paintcolorhq"],
         contactPoint: { "@type": "ContactPoint", contactType: "customer support", url: "https://www.paintcolorhq.com/contact" },
       }} />
 

--- a/src/app/tools/color-identifier/page.tsx
+++ b/src/app/tools/color-identifier/page.tsx
@@ -24,16 +24,6 @@ export default function ColorIdentifierPage() {
   return (
     <div className="min-h-screen bg-surface">
       <JsonLd data={{
-        "@context": "https://schema.org", "@type": "HowTo",
-        name: "Find Paint Colors from a Photo",
-        description: "Upload a photo, click any spot, and instantly find matching paint colors from Sherwin-Williams, Benjamin Moore, Behr, and more.",
-        step: [
-          { "@type": "HowToStep", name: "Upload a photo", text: "Upload a photo from your device or snap one with your camera. Any image format works." },
-          { "@type": "HowToStep", name: "Click a spot", text: "Click a spot on the image to sample the color. The tool reads the exact pixel color at that point." },
-          { "@type": "HowToStep", name: "Get matches", text: "Instantly see the closest matching paint colors from 25,000+ colors across 14 major brands, matched using the Delta E 2000 formula." },
-        ],
-      }} />
-      <JsonLd data={{
         "@context": "https://schema.org", "@type": "WebApplication",
         name: "Photo Color Identifier — Find Paint Colors from Any Photo",
         description: "Upload any photo and click a pixel to match it against 25,000+ paint colors from 14 brands (Sherwin-Williams, Benjamin Moore, Behr, Valspar, PPG, Dunn-Edwards, Farrow & Ball) using the CIEDE2000 Delta E 2000 color difference formula.",

--- a/src/app/tools/paint-calculator/page.tsx
+++ b/src/app/tools/paint-calculator/page.tsx
@@ -24,18 +24,6 @@ export default function PaintCalculatorPage() {
   return (
     <div className="min-h-screen bg-surface">
       <JsonLd data={{
-        "@context": "https://schema.org", "@type": "HowTo",
-        name: "How to Calculate How Much Paint You Need",
-        description: "Calculate paint needed for a room using wall dimensions, doors, windows, and number of coats.",
-        step: [
-          { "@type": "HowToStep", name: "Measure your room", text: "Measure the length, width, and height of the room in feet." },
-          { "@type": "HowToStep", name: "Calculate wall area", text: "Multiply 2 times (length + width) times height to get total wall area." },
-          { "@type": "HowToStep", name: "Subtract doors and windows", text: "Subtract 21 sq ft per door and 15 sq ft per window." },
-          { "@type": "HowToStep", name: "Account for coats", text: "Multiply paintable area by number of coats (usually 2)." },
-          { "@type": "HowToStep", name: "Calculate gallons", text: "Divide total area by 350 sq ft per gallon and round up." },
-        ],
-      }} />
-      <JsonLd data={{
         "@context": "https://schema.org", "@type": "WebApplication",
         name: "Paint Calculator — How Much Paint Do I Need?",
         description: "Calculate exactly how many gallons of paint you need. Enter room dimensions (length, width, height), subtract doors and windows, and get coverage based on the industry-standard rate of 350 sq ft per gallon for interior latex paint.",

--- a/src/app/tools/palette-generator/page.tsx
+++ b/src/app/tools/palette-generator/page.tsx
@@ -24,16 +24,6 @@ export default function PaletteGeneratorPage() {
   return (
     <div className="min-h-screen bg-surface">
       <JsonLd data={{
-        "@context": "https://schema.org", "@type": "HowTo",
-        name: "How to Generate a Paint Color Palette",
-        description: "Pick a starting color and generate coordinated paint palettes with walls, trim, accent, and pop roles.",
-        step: [
-          { "@type": "HowToStep", name: "Pick a color", text: "Use the color picker or type a hex code to choose your starting color. Optionally select a brand to filter results." },
-          { "@type": "HowToStep", name: "Choose a scheme", text: "Five coordinated palettes appear instantly, each with Walls, Trim, Accent, and Pop roles matched to real paint colors." },
-          { "@type": "HowToStep", name: "Save or visualize", text: "Open any palette in the Room Visualizer to preview on walls, or save it to a project for later reference." },
-        ],
-      }} />
-      <JsonLd data={{
         "@context": "https://schema.org", "@type": "WebApplication",
         name: "Paint Palette Generator",
         description: "Build coordinated paint palettes from any starting color. Generates complementary, analogous, and triadic schemes matched to real paint colors.",

--- a/src/app/tools/room-visualizer/page.tsx
+++ b/src/app/tools/room-visualizer/page.tsx
@@ -66,16 +66,6 @@ export default async function RoomVisualizerPage({ searchParams }: PageProps) {
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
       }} />
       <JsonLd data={{
-        "@context": "https://schema.org", "@type": "HowTo",
-        name: "Preview Paint Colors in a Room",
-        description: "See how paint colors look in a room before you buy. Pick colors for walls, accent wall, trim, and floor.",
-        step: [
-          { "@type": "HowToStep", name: "Select a region", text: "Click directly on the room image or use the buttons below it to select walls, trim, accent wall, or floor." },
-          { "@type": "HowToStep", name: "Pick a color", text: "Use the color picker or type a hex code. The room updates instantly so you can see the result." },
-          { "@type": "HowToStep", name: "Find paint matches", text: "Discover which real paint colors from Sherwin-Williams, Benjamin Moore, Behr, and other brands are closest to your selection." },
-        ],
-      }} />
-      <JsonLd data={{
         "@context": "https://schema.org", "@type": "FAQPage",
         mainEntity: [
           { "@type": "Question", name: "What is a room color visualizer?", acceptedAnswer: { "@type": "Answer", text: "A room color visualizer is a free online tool that lets you preview paint colors on walls, ceiling, trim, accent wall, and floor in a realistic room scene before you buy paint. Paint Color HQ's visualizer updates instantly as you pick colors and supports all major paint brands." } },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+const AUTH_PATH_PREFIXES = ["/dashboard", "/auth", "/account"];
+
 export async function middleware(request: NextRequest) {
   // Enforce www canonical domain (301 redirect)
   const host = request.headers.get("host") ?? "";
@@ -27,6 +29,19 @@ export async function middleware(request: NextRequest) {
   // Doing it here yields a proper 308.
   const colorRedirect = await maybeColorSlugRedirect(request);
   if (colorRedirect) return colorRedirect;
+
+  // Skip Supabase session refresh for anonymous traffic on public routes.
+  // Calling auth.getUser() invokes setAll with cookies, which makes Vercel
+  // mark responses `private, no-store` and bypass the ISR cache.
+  const hasSupabaseSession = request.cookies
+    .getAll()
+    .some((c) => c.name.startsWith("sb-"));
+  const needsAuth = AUTH_PATH_PREFIXES.some((prefix) =>
+    request.nextUrl.pathname.startsWith(prefix),
+  );
+  if (!hasSupabaseSession && !needsAuth) {
+    return NextResponse.next({ request });
+  }
 
   let supabaseResponse = NextResponse.next({ request });
 


### PR DESCRIPTION
## Summary

Eight fixes from the `/seo audit` run on May 7. The middleware change is the highest-leverage item — Supabase auth refresh was setting cookies on every public-page response, forcing Vercel edge to mark them `private, no-store` and bypass ISR cache. Anonymous traffic on public routes now short-circuits before touching cookies, so color/family/brand/blog pages can actually serve from edge cache.

### Schema cleanup
- Remove deprecated `HowTo` from all 4 tool pages (Google retired Sept 2023)
- Replace `WebPage + DefinedTerm` with `Product + isSimilarTo` on color detail pages — adds `sku`, `mpn`, `brand`, `color`, `additionalProperty` (Hex/RGB/LRV/undertone/family), and top 5 cross-brand matches under Delta E < 2 as `isSimilarTo` references
- Add Pinterest `sameAs` to homepage Organization
- Add Wikipedia `sameAs` to 6 brand Organizations (SW, BM, Behr, PPG, Valspar, Farrow & Ball — every URL HEAD-checked before commit; Dunn-Edwards / Dutch Boy skipped, no Wikipedia article)
- Add `item` URLs to last `BreadcrumbList` items on brand + match-listing pages
- Upgrade `BlogPosting.publisher.logo` from og-image.webp (1200×630) to logo.webp (600×60) for Article rich-result eligibility; upgrade `image` from string to `ImageObject` with width/height

### GEO
- Add `OAI-SearchBot` Allow block to robots.txt (ChatGPT search agent)
- Reorder `llms.txt` — move Common Questions Q&A immediately after the description, before AI parsers truncate at token limits

### Middleware ISR (the big one)
- New `AUTH_PATH_PREFIXES = ["/dashboard", "/auth", "/account"]`
- Short-circuit `NextResponse.next({ request })` when no `sb-*` cookie present AND path is not auth-protected. Skips the `auth.getUser()` cookie write entirely.

## Test plan

- [ ] Wait for Vercel preview build to finish
- [ ] Verify ISR cache is restored on color page:
      `curl -sI <preview>/colors/sherwin-williams/agreeable-gray-sw-7029 | grep -E 'cache-control\|x-vercel-cache\|age'`
      First request: MISS. Second request (within revalidate window): HIT, `public` cache-control.
- [ ] Verify same on a family page (`/colors/family/blue`) and a brand page (`/brands/sherwin-williams`)
- [ ] Confirm logged-out anonymous flow still loads correctly (no auth-related console errors in browser)
- [ ] Confirm logged-in flow still works — visit `/dashboard`, log in if needed, sessions persist across navigations
- [ ] Validate one color page in https://search.google.com/test/rich-results to confirm Product schema parses cleanly
- [ ] Validate match-listing page BreadcrumbList in same tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)