### PR TITLE
perf(seo): add generateStaticParams to color page for ISR

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -21,6 +21,83 @@ import { PairingSelector } from "@/components/pairing-selector";
 
 export const revalidate = 3600;
 
+// Pre-render popular colors at build time; all others are generated on
+// demand and cached via ISR (revalidate=3600) on first visit. Without
+// generateStaticParams Next.js 16 falls back to fully dynamic SSR for
+// dynamic route segments — `revalidate` alone does not opt in.
+// https://nextjs.org/docs/app/api-reference/functions/generate-static-params#dynamic-segments-without-generatestaticparams
+//
+// Slug source: src/lib/brand-content.tsx + src/lib/family-content.tsx
+// (only slugs in active code, so they're known to match the database).
+const POPULAR_COLOR_SLUGS: Array<{ brandSlug: string; colorSlug: string }> = [
+  // Sherwin-Williams
+  { brandSlug: "sherwin-williams", colorSlug: "agreeable-gray-7029" },
+  { brandSlug: "sherwin-williams", colorSlug: "alabaster-7008" },
+  { brandSlug: "sherwin-williams", colorSlug: "naval-6244" },
+  { brandSlug: "sherwin-williams", colorSlug: "pure-white-7005" },
+  { brandSlug: "sherwin-williams", colorSlug: "repose-gray-7015" },
+  { brandSlug: "sherwin-williams", colorSlug: "cavern-clay-7701" },
+  { brandSlug: "sherwin-williams", colorSlug: "fireworks-6867" },
+  { brandSlug: "sherwin-williams", colorSlug: "grounded-6089" },
+  { brandSlug: "sherwin-williams", colorSlug: "quaint-coral-6536" },
+  { brandSlug: "sherwin-williams", colorSlug: "tricorn-black-6258" },
+  // Benjamin Moore
+  { brandSlug: "benjamin-moore", colorSlug: "chantilly-lace-oc-65" },
+  { brandSlug: "benjamin-moore", colorSlug: "edgecomb-gray-hc-173" },
+  { brandSlug: "benjamin-moore", colorSlug: "hale-navy-hc-154" },
+  { brandSlug: "benjamin-moore", colorSlug: "revere-pewter-hc-172" },
+  { brandSlug: "benjamin-moore", colorSlug: "simply-white-oc-117" },
+  { brandSlug: "benjamin-moore", colorSlug: "white-dove-oc-17" },
+  { brandSlug: "benjamin-moore", colorSlug: "burnt-caramel-2167-10" },
+  { brandSlug: "benjamin-moore", colorSlug: "caliente-af-290" },
+  { brandSlug: "benjamin-moore", colorSlug: "cinnamon-slate-2113-40" },
+  { brandSlug: "benjamin-moore", colorSlug: "hawthorne-yellow-hc-4" },
+  { brandSlug: "benjamin-moore", colorSlug: "wrought-iron-2124-10" },
+  // Behr
+  { brandSlug: "behr", colorSlug: "cameo-white-w-d-200" },
+  { brandSlug: "behr", colorSlug: "dolphin-fin-790c-3" },
+  { brandSlug: "behr", colorSlug: "silver-drop-790c-2" },
+  { brandSlug: "behr", colorSlug: "ultra-pure-white-1850" },
+  { brandSlug: "behr", colorSlug: "whisper-white-w-d-300" },
+  { brandSlug: "behr", colorSlug: "red-pepper-ppu2-02" },
+  // Dunn-Edwards
+  { brandSlug: "dunn-edwards", colorSlug: "bone-china-dew339" },
+  { brandSlug: "dunn-edwards", colorSlug: "cold-water-de6316" },
+  { brandSlug: "dunn-edwards", colorSlug: "cottage-white-dew318" },
+  { brandSlug: "dunn-edwards", colorSlug: "foggy-day-de6226" },
+  { brandSlug: "dunn-edwards", colorSlug: "swiss-coffee-dew341" },
+  // Farrow & Ball
+  { brandSlug: "farrow-ball", colorSlug: "ammonite-274" },
+  { brandSlug: "farrow-ball", colorSlug: "cornforth-white-228" },
+  { brandSlug: "farrow-ball", colorSlug: "elephants-breath-229" },
+  { brandSlug: "farrow-ball", colorSlug: "hague-blue-30" },
+  { brandSlug: "farrow-ball", colorSlug: "stiffkey-blue-281" },
+  // PPG
+  { brandSlug: "ppg", colorSlug: "delicate-white-1001-1" },
+  { brandSlug: "ppg", colorSlug: "gypsum-1006-1" },
+  { brandSlug: "ppg", colorSlug: "olive-sprig-1125-4" },
+  { brandSlug: "ppg", colorSlug: "stonehenge-greige-1024-5" },
+  { brandSlug: "ppg", colorSlug: "swirling-smoke-1007-2" },
+  // Valspar
+  { brandSlug: "valspar", colorSlug: "gravity-4005-1b" },
+  { brandSlug: "valspar", colorSlug: "gray-silt-6002-1c" },
+  { brandSlug: "valspar", colorSlug: "notre-dame-5006-1b" },
+  { brandSlug: "valspar", colorSlug: "safari-beige-6006-2b" },
+  { brandSlug: "valspar", colorSlug: "warm-eucalyptus-8004-28f" },
+];
+
+export async function generateStaticParams() {
+  // Verify each slug exists in the database before claiming it as a static
+  // param — protects the build from stale entries when a slug gets renamed.
+  const verified = await Promise.all(
+    POPULAR_COLOR_SLUGS.map(async (params) => {
+      const color = await getColorBySlug(params.brandSlug, params.colorSlug);
+      return color ? params : null;
+    }),
+  );
+  return verified.filter((p): p is { brandSlug: string; colorSlug: string } => p !== null);
+}
+
 function hexToHsl(hex: string): [number, number, number] {
   const r = parseInt(hex.slice(1, 3), 16) / 255;
   const g = parseInt(hex.slice(3, 5), 16) / 255;


### PR DESCRIPTION
## Summary

Follow-up to PR #30 (middleware ISR cache fix). Verification on production after #30 merged showed color/family pages were **still** uncacheable (`x-vercel-cache: MISS`, `cache-control: private, no-cache, no-store`) despite the middleware change correctly preventing cookie writes on anonymous responses.

Root cause: in Next.js 16, dynamic route segments without `generateStaticParams` fall back to fully dynamic SSR. `export const revalidate = 3600` alone does NOT opt the route into ISR — confirmed against the official Next.js docs:

> If a dynamic segment could be prerendered but isn't because it's missing `generateStaticParams`, the route will fallback to dynamic rendering at request time.

## Fix

Add `generateStaticParams` to `src/app/colors/[brandSlug]/[colorSlug]/page.tsx`. Pre-renders ~47 popular colors at build time (sourced from active `brand-content.tsx` + `family-content.tsx` references — slugs known to match the DB). The other ~24,950 colors are generated on-demand and cached via ISR (`revalidate = 3600`) once a user visits them — Next.js's `dynamicParams = true` default behavior.

Each slug is verified against the DB at build time so a stale entry doesn't break the build.

## Out of scope

`/colors/family/[familySlug]` is also Dynamic for a different reason: it reads `await searchParams` in the Server Component for filters/pagination. Fixing that requires moving filter handling to a client component or splitting routes — separate PR.

## Test plan

- [ ] Preview build succeeds (verifies ~47 hardcoded slugs still match DB)
- [ ] On preview, color detail page returns `x-vercel-cache: HIT` on second request:
      ``curl -sI -H "x-vercel-protection-bypass: <token>" <preview-url>/colors/sherwin-williams/agreeable-gray-7029 | grep -iE 'cache-control|x-vercel-cache'``
- [ ] On preview, popular slug returns `x-vercel-cache: PRERENDER` (built at build time)
- [ ] On preview, less-popular slug returns `MISS` on first request, `HIT` after (generated on-demand)
- [ ] After merge to main, verify same on production (no token needed)
- [ ] Confirm Supabase egress drops as ISR cache populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)