### PR TITLE
perf(build): cache-shortcut for build-match-data prebuild

### DIFF
--- a/scripts/build-match-data.ts
+++ b/scripts/build-match-data.ts
@@ -44,8 +44,42 @@ const supabase = createClient(supabaseUrl, serviceKey, {
 });
 
 const OUT_DIR = path.resolve(__dirname, "../public/match-data");
+// Vercel preserves .next/cache between builds. Use it to skip regeneration
+// when neither colors nor cross_brand_matches has changed since last build.
+const CACHE_DIR = path.resolve(__dirname, "../.next/cache/match-data");
+const CACHE_MARKER = path.join(CACHE_DIR, ".hash");
 const TOP_N_PER_COLOR = 50;
 const MATCH_BATCH_SIZE = 1000; // PostgREST default cap is 1000 rows/request
+
+async function getDataHash(): Promise<string | null> {
+  // Cheap fingerprint: row counts across both source tables. cross_brand_matches
+  // is the dominant dataset (~1.5M rows) and is append-only on compute-matches
+  // re-runs, so count is a reliable change signal. Including colors guards
+  // against name/slug edits that would render stale embedded metadata.
+  const matchesRes = await supabase
+    .from("cross_brand_matches")
+    .select("*", { count: "exact", head: true });
+  if (matchesRes.error) return null;
+  const colorsRes = await supabase
+    .from("colors")
+    .select("*", { count: "exact", head: true });
+  if (colorsRes.error) return null;
+  return `matches:${matchesRes.count}|colors:${colorsRes.count}`;
+}
+
+function copyDirSync(src: string, dest: string): number {
+  fs.mkdirSync(dest, { recursive: true });
+  let copied = 0;
+  for (const file of fs.readdirSync(src)) {
+    const s = path.join(src, file);
+    const d = path.join(dest, file);
+    if (fs.statSync(s).isFile()) {
+      fs.copyFileSync(s, d);
+      copied++;
+    }
+  }
+  return copied;
+}
 
 interface ColorRow {
   id: string;
@@ -79,6 +113,31 @@ interface OutputMatch {
 async function main() {
   console.log(`Output dir: ${OUT_DIR}`);
   fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  // Cache shortcut — skip the 5-minute generation when neither colors nor
+  // cross_brand_matches has changed since the previous build. Vercel's
+  // build cache preserves .next/cache/ between deploys, so a cached copy
+  // of the JSON files lives there and we copy to public/ at the start.
+  const currentHash = await getDataHash();
+  if (currentHash && fs.existsSync(CACHE_MARKER) && fs.existsSync(CACHE_DIR)) {
+    const savedHash = fs.readFileSync(CACHE_MARKER, "utf-8").trim();
+    const cachedFiles = fs
+      .readdirSync(CACHE_DIR)
+      .filter((f) => f.endsWith(".json"));
+    if (savedHash === currentHash && cachedFiles.length > 0) {
+      console.log(
+        `Cache hit (${currentHash}). Copying ${cachedFiles.length} files from .next/cache to public/...`,
+      );
+      const copied = copyDirSync(CACHE_DIR, OUT_DIR);
+      console.log(`Copied ${copied} files. Skipping regeneration.`);
+      return;
+    }
+    console.log(
+      `Cache miss (saved=${savedHash}, current=${currentHash}). Regenerating...`,
+    );
+  } else if (currentHash) {
+    console.log(`No cache marker. Generating fresh (current hash ${currentHash})...`);
+  }
 
   // 1. Load brands map
   console.log("\n[1/3] Loading brands...");
@@ -222,6 +281,21 @@ async function main() {
     console.log(
       `Avg per color: ${(totalBytes / files.length / 1024).toFixed(1)} KB`,
     );
+  }
+
+  // Persist to the build cache so the next deploy can short-circuit when
+  // data is unchanged. currentHash was computed at the top of main().
+  if (currentHash) {
+    console.log(`\nSaving to .next/cache for next-build shortcut...`);
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    // Clear stale files first — a removed color must not leave a stale JSON
+    // behind in the cache that would re-appear on the next build.
+    for (const f of fs.readdirSync(CACHE_DIR)) {
+      if (f.endsWith(".json")) fs.unlinkSync(path.join(CACHE_DIR, f));
+    }
+    const copied = copyDirSync(OUT_DIR, CACHE_DIR);
+    fs.writeFileSync(CACHE_MARKER, currentHash);
+    console.log(`Cached ${copied} files with hash ${currentHash}.`);
   }
 }
 


### PR DESCRIPTION
## Summary

Cuts deploy time for code-only changes from ~6 min back to under 1 min.

The April 30 egress reduction added a prebuild step (\`scripts/build-match-data.ts\`) that pre-computes ~23,000 cross-brand match JSON files to \`public/match-data/\`. Without the prebuild, color pages hit Supabase on every render (~300 MB egress per million renders). With it, deploys went from ~45s to ~6m — and the prebuild runs on **every** deploy, even when the underlying data hasn't changed.

This PR adds a cache shortcut. Vercel preserves \`.next/cache/\` between deploys, so we persist the generated JSON files there plus a marker containing a content hash.

## How it works

\`\`\`
prebuild start
  ├─ get current hash = count(cross_brand_matches) | count(colors)   (~200ms)
  ├─ marker in .next/cache exists?
  │    └─ yes → hash matches?
  │         └─ yes → copy .next/cache/match-data/* to public/match-data/  ← FAST PATH
  │              exit (skip 5min regeneration)
  └─ no or hash mismatch → full regeneration (existing path)
       └─ at the end, copy public/match-data/* to .next/cache/match-data/
          + write marker → cached for next build
\`\`\`

## Hash choice

Row counts on both tables (\`cross_brand_matches\`, \`colors\`). Both are head-count queries so they're cheap (no row scan). Sufficient because:
- \`cross_brand_matches\` is append-only — it's rewritten in bulk by \`scripts/compute-matches.ts\` and never edited in place
- \`colors\` only changes when \`scripts/import-*.ts\` runs

Edge case: rows edited in place without count changes would produce a stale cache. Doesn't happen in normal operation. Fix is to run \`rm -rf .next/cache\` and redeploy.

## Test plan

- [ ] First preview deploy builds normally (~6 min) — cache miss path
- [ ] Second preview deploy on the same branch with no data change — should complete in under 1 min (cache hit path)
- [ ] Build log shows \"Cache hit\" message and file copy count
- [ ] Color detail pages still serve correct match data (verify a few with curl)
- [ ] After merge, watch first 2-3 production deploys to confirm short-circuit is firing

## Notes

- Independent of PR #31 (color-page generateStaticParams). Can ship either order.
- Conservative implementation — if the cache mechanism breaks for any reason, falls back to the full regeneration path. Worst case is the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)