### PR TITLE
perf(seo): make family page ISR-cacheable

### DIFF
--- a/src/app/api/family/[familySlug]/colors/route.ts
+++ b/src/app/api/family/[familySlug]/colors/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getColorsByFamily, getColorsByFamilyCount } from "@/lib/queries";
+
+interface RouteContext {
+  params: Promise<{ familySlug: string }>;
+}
+
+const PER_PAGE = 60;
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const { familySlug } = await params;
+  const sp = request.nextUrl.searchParams;
+  const brand = sp.get("brand") || undefined;
+  const undertone = sp.get("undertone") || undefined;
+  const page = Math.max(1, parseInt(sp.get("page") ?? "1", 10) || 1);
+
+  try {
+    const [colors, totalCount] = await Promise.all([
+      getColorsByFamily(familySlug, {
+        brandSlug: brand,
+        undertone,
+        limit: PER_PAGE,
+        offset: (page - 1) * PER_PAGE,
+      }),
+      getColorsByFamilyCount(familySlug, { brandSlug: brand, undertone }),
+    ]);
+
+    return NextResponse.json(
+      {
+        colors,
+        totalCount,
+        totalPages: Math.max(1, Math.ceil(totalCount / PER_PAGE)),
+        page,
+        perPage: PER_PAGE,
+      },
+      {
+        headers: {
+          "Cache-Control":
+            "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+        },
+      },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Query failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -1,9 +1,11 @@
+import { Suspense } from "react";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { FamilyColorLibrary } from "@/components/family-color-library";
+import { FamilyColorLibraryFallback } from "@/components/family-color-library-fallback";
 import { getColorsByFamily, getColorsByFamilyCount, getAllBrands } from "@/lib/queries";
 import { getFamilyContent } from "@/lib/family-content";
 import { TrackPage } from "@/components/track-page";
@@ -133,18 +135,32 @@ export default async function ColorFamilyPage({ params }: PageProps) {
         </section>
       )}
 
-      {/* Color Library \u2014 client-driven for filter/pagination interactivity. The
-          server-rendered initial state (page 1, unfiltered) is what Google
-          indexes; client refetches via /api/family/[slug]/colors on URL change. */}
+      {/* Color Library \u2014 client-driven for filter/pagination interactivity.
+          Suspense fallback renders the static unfiltered page-1 state, which
+          is what Googlebot sees. useSearchParams in the client component
+          requires the Suspense boundary so the rest of the page can still
+          be statically prerendered. */}
       <section className="py-24 px-6 md:px-12 bg-surface-container-low">
         <div className="max-w-7xl mx-auto">
-          <FamilyColorLibrary
-            familySlug={familySlug}
-            familyName={familyName}
-            brands={brands}
-            initialColors={colors}
-            initialTotalCount={totalCount}
-          />
+          <Suspense
+            fallback={
+              <FamilyColorLibraryFallback
+                familySlug={familySlug}
+                familyName={familyName}
+                brands={brands}
+                initialColors={colors}
+                initialTotalCount={totalCount}
+              />
+            }
+          >
+            <FamilyColorLibrary
+              familySlug={familySlug}
+              familyName={familyName}
+              brands={brands}
+              initialColors={colors}
+              initialTotalCount={totalCount}
+            />
+          </Suspense>
         </div>
       </section>
 

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
-import { ColorCard } from "@/components/color-card";
+import { FamilyColorLibrary } from "@/components/family-color-library";
 import { getColorsByFamily, getColorsByFamilyCount, getAllBrands } from "@/lib/queries";
 import { getFamilyContent } from "@/lib/family-content";
 import { TrackPage } from "@/components/track-page";
@@ -25,31 +25,25 @@ const familyColors: Record<string, { hex: string; border?: boolean }> = {
   tan: { hex: "#D2B48C" }, neutral: { hex: "#C7C1B7" },
 };
 
-const undertoneColors: Record<string, string> = {
-  warm: "#E8B87D", cool: "#7DA8CC", neutral: "#B8B4AC",
-};
-
 interface PageProps {
   params: Promise<{ familySlug: string }>;
-  searchParams: Promise<{ brand?: string; undertone?: string; page?: string }>;
 }
 
 export async function generateStaticParams() {
   return validFamilies.map((f) => ({ familySlug: f }));
 }
 
-export async function generateMetadata({ params, searchParams }: PageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { familySlug } = await params;
-  const { brand, undertone, page: pageParam } = await searchParams;
   const name = familySlug.replace(/-/g, " ");
   const url = `https://www.paintcolorhq.com/colors/family/${familySlug}`;
-  const currentPage = parseInt(pageParam ?? "1", 10) || 1;
-  const shouldNoindex = currentPage > 1 || !!brand || !!undertone;
+  // Canonical always points to the unfiltered base URL. Filter/pagination
+  // variants now share the same static HTML and refetch client-side, so the
+  // canonical consolidates them for Google.
   return {
     title: `${capitalize(name)} Paint Colors - All Brands`,
     description: `Browse ${name} paint colors from Sherwin-Williams, Benjamin Moore, Behr, and more. Compare colors with hex codes and LRV values.`,
     alternates: { canonical: url },
-    ...(shouldNoindex && { robots: { index: false, follow: true } }),
     openGraph: { title: `${capitalize(name)} Paint Colors`, description: `Browse ${name} paint colors from Sherwin-Williams, Benjamin Moore, Behr, and more.`, url },
   };
 }
@@ -63,23 +57,22 @@ function JsonLd({ data }: { data: object }) {
   return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />;
 }
 
-export default async function ColorFamilyPage({ params, searchParams }: PageProps) {
+export default async function ColorFamilyPage({ params }: PageProps) {
   const { familySlug } = await params;
-  const { brand: brandFilter, undertone: undertoneFilter, page: pageParam } = await searchParams;
 
   if (!validFamilies.includes(familySlug)) notFound();
 
-  const requestedPage = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
   const perPage = 60;
 
-  const totalCount = await getColorsByFamilyCount(familySlug, { brandSlug: brandFilter ?? undefined, undertone: undertoneFilter ?? undefined });
-  const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
-  if (requestedPage > totalPages) notFound();
-  const currentPage = requestedPage;
-
-  const [colors, brands] = await Promise.all([
-    getColorsByFamily(familySlug, { brandSlug: brandFilter ?? undefined, undertone: undertoneFilter ?? undefined, limit: perPage, offset: (currentPage - 1) * perPage }),
+  // Server renders the canonical (unfiltered, page 1) variant. Filters and
+  // pagination are handled client-side by FamilyColorLibrary, which refetches
+  // from /api/family/[slug]/colors when URL params are present. Reading
+  // searchParams on the server here would force dynamic rendering and kill
+  // ISR caching for the canonical URL.
+  const [colors, brands, totalCount] = await Promise.all([
+    getColorsByFamily(familySlug, { limit: perPage, offset: 0 }),
     getAllBrands(),
+    getColorsByFamilyCount(familySlug),
   ]);
 
   const familyName = capitalize(familySlug.replace(/-/g, " "));
@@ -102,7 +95,7 @@ export default async function ColorFamilyPage({ params, searchParams }: PageProp
           ]},
         ],
       }} />
-      <TrackPage eventName="page_view_enriched" params={{ page_type: "family", color_family: familySlug, brand_filter: brandFilter ?? "all", undertone_filter: undertoneFilter ?? "all", page_number: currentPage, result_count: totalCount }} />
+      <TrackPage eventName="page_view_enriched" params={{ page_type: "family", color_family: familySlug, result_count: totalCount }} />
       <Header />
 
       {/* Hero */}
@@ -140,110 +133,18 @@ export default async function ColorFamilyPage({ params, searchParams }: PageProp
         </section>
       )}
 
-      {/* Color Library */}
+      {/* Color Library \u2014 client-driven for filter/pagination interactivity. The
+          server-rendered initial state (page 1, unfiltered) is what Google
+          indexes; client refetches via /api/family/[slug]/colors on URL change. */}
       <section className="py-24 px-6 md:px-12 bg-surface-container-low">
         <div className="max-w-7xl mx-auto">
-          <div className="flex flex-col md:flex-row md:items-center justify-between gap-8 mb-12">
-            <div>
-              <h2 className="font-headline text-4xl font-bold tracking-tight text-on-surface">{familyName} Color Library</h2>
-              <p className="text-outline mt-2">{totalCount.toLocaleString()} colors{brandFilter ? ` from ${brandFilter}` : ""}{undertoneFilter ? ` \u00B7 ${undertoneFilter} undertone` : ""}.</p>
-            </div>
-          </div>
-
-          {/* Brand filter */}
-          <div className="flex flex-wrap gap-2 mb-4">
-            <Link
-              href={`/colors/family/${familySlug}${undertoneFilter ? `?undertone=${undertoneFilter}` : ""}`}
-              className={`rounded-full px-4 py-2 text-sm font-headline font-bold transition-all ${!brandFilter ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant hover:text-primary"}`}
-            >
-              All Brands
-            </Link>
-            {brands.map((b) => {
-              const p = new URLSearchParams();
-              p.set("brand", b.slug);
-              if (undertoneFilter) p.set("undertone", undertoneFilter);
-              return (
-                <Link key={b.slug} href={`/colors/family/${familySlug}?${p.toString()}`}
-                  className={`rounded-full px-4 py-2 text-sm font-headline font-bold transition-all ${brandFilter === b.slug ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant hover:text-primary"}`}
-                >{b.name}</Link>
-              );
-            })}
-          </div>
-
-          {/* Undertone filter */}
-          <div className="flex flex-wrap gap-2 mb-10">
-            <Link
-              href={`/colors/family/${familySlug}${brandFilter ? `?brand=${brandFilter}` : ""}`}
-              className={`rounded-full px-4 py-2 text-sm transition-all flex items-center gap-2 ${!undertoneFilter ? "bg-secondary text-on-secondary font-bold" : "bg-surface-container-lowest text-on-surface-variant hover:text-secondary"}`}
-            >
-              All Undertones
-            </Link>
-            {(["warm", "cool", "neutral"] as const).map((tone) => {
-              const p = new URLSearchParams();
-              if (brandFilter) p.set("brand", brandFilter);
-              p.set("undertone", tone);
-              return (
-                <Link key={tone} href={`/colors/family/${familySlug}?${p.toString()}`}
-                  className={`rounded-full px-4 py-2 text-sm capitalize transition-all flex items-center gap-2 ${undertoneFilter === tone ? "bg-secondary text-on-secondary font-bold" : "bg-surface-container-lowest text-on-surface-variant hover:text-secondary"}`}
-                >
-                  <span className="inline-block h-3.5 w-3.5 rounded-full shrink-0" style={{ backgroundColor: undertoneColors[tone] }} />
-                  {tone}
-                </Link>
-              );
-            })}
-          </div>
-
-          {/* Color grid */}
-          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-            {colors.map((color) => (
-              <ColorCard key={color.id} name={color.name} hex={color.hex} brandName={color.brand.name} brandSlug={color.brand.slug} colorSlug={color.slug} colorNumber={color.color_number} />
-            ))}
-          </div>
-
-          {colors.length === 0 && (
-            <p className="mt-12 text-center text-on-surface-variant">No {familyName.toLowerCase()} colors found{brandFilter ? ` from this brand` : ""}.</p>
-          )}
-
-          {/* Pagination */}
-          {totalPages > 1 && (() => {
-            function pageUrl(page: number) {
-              const p = new URLSearchParams();
-              if (brandFilter) p.set("brand", brandFilter);
-              if (undertoneFilter) p.set("undertone", undertoneFilter);
-              if (page > 1) p.set("page", String(page));
-              const qs = p.toString();
-              return `/colors/family/${familySlug}${qs ? `?${qs}` : ""}`;
-            }
-            const pages: (number | "ellipsis")[] = [];
-            const addPage = (n: number) => { if (n >= 1 && n <= totalPages && !pages.includes(n)) pages.push(n); };
-            addPage(1);
-            if (currentPage > 3) pages.push("ellipsis");
-            addPage(currentPage - 1);
-            addPage(currentPage);
-            addPage(currentPage + 1);
-            if (currentPage < totalPages - 2) pages.push("ellipsis");
-            addPage(totalPages);
-
-            return (
-              <nav className="mt-12 flex items-center justify-center gap-2">
-                {currentPage > 1 && (
-                  <Link href={pageUrl(currentPage - 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">Previous</Link>
-                )}
-                {pages.map((page, i) =>
-                  page === "ellipsis" ? (
-                    <span key={`e${i}`} className="px-2 text-outline">...</span>
-                  ) : (
-                    <Link key={page} href={pageUrl(page)}
-                      className={`rounded-xl px-4 py-2.5 text-sm font-headline font-bold transition-all ${page === currentPage ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant border border-outline-variant/15 hover:text-primary"}`}
-                    >{page}</Link>
-                  )
-                )}
-                {currentPage < totalPages && (
-                  <Link href={pageUrl(currentPage + 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">Next</Link>
-                )}
-              </nav>
-            );
-          })()}
+          <FamilyColorLibrary
+            familySlug={familySlug}
+            familyName={familyName}
+            brands={brands}
+            initialColors={colors}
+            initialTotalCount={totalCount}
+          />
         </div>
       </section>
 

--- a/src/components/family-color-library-fallback.tsx
+++ b/src/components/family-color-library-fallback.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import { ColorCard } from "./color-card";
+
+interface Brand {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface FamilyColor {
+  id: string;
+  name: string;
+  slug: string;
+  hex: string;
+  color_number?: string | null;
+  brand: { name: string; slug: string };
+}
+
+interface Props {
+  familySlug: string;
+  familyName: string;
+  brands: Brand[];
+  initialColors: FamilyColor[];
+  initialTotalCount: number;
+}
+
+const UNDERTONE_COLORS: Record<string, string> = {
+  warm: "#E8B87D",
+  cool: "#7DA8CC",
+  neutral: "#B8B4AC",
+};
+
+const PER_PAGE = 60;
+
+// Static, server-rendered fallback for the FamilyColorLibrary client
+// component. Renders the unfiltered page-1 state with non-interactive
+// (Link-only) filter pills. Used as the Suspense fallback while the
+// client subtree hydrates — this is what Googlebot sees, so the color
+// grid and filter links must be present here.
+export function FamilyColorLibraryFallback({
+  familySlug,
+  familyName,
+  brands,
+  initialColors,
+  initialTotalCount,
+}: Props) {
+  const totalPages = Math.max(1, Math.ceil(initialTotalCount / PER_PAGE));
+
+  return (
+    <>
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-8 mb-12">
+        <div>
+          <h2 className="font-headline text-4xl font-bold tracking-tight text-on-surface">
+            {familyName} Color Library
+          </h2>
+          <p className="text-outline mt-2">
+            {initialTotalCount.toLocaleString()} colors.
+          </p>
+        </div>
+      </div>
+
+      {/* Brand filter */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        <span className="rounded-full px-4 py-2 text-sm font-headline font-bold bg-primary text-on-primary">
+          All Brands
+        </span>
+        {brands.map((b) => (
+          <Link
+            key={b.slug}
+            href={`/colors/family/${familySlug}?brand=${b.slug}`}
+            className="rounded-full px-4 py-2 text-sm font-headline font-bold bg-surface-container-lowest text-on-surface-variant hover:text-primary transition-all"
+          >
+            {b.name}
+          </Link>
+        ))}
+      </div>
+
+      {/* Undertone filter */}
+      <div className="flex flex-wrap gap-2 mb-10">
+        <span className="rounded-full px-4 py-2 text-sm bg-secondary text-on-secondary font-bold flex items-center gap-2">
+          All Undertones
+        </span>
+        {(["warm", "cool", "neutral"] as const).map((tone) => (
+          <Link
+            key={tone}
+            href={`/colors/family/${familySlug}?undertone=${tone}`}
+            className="rounded-full px-4 py-2 text-sm capitalize bg-surface-container-lowest text-on-surface-variant hover:text-secondary transition-all flex items-center gap-2"
+          >
+            <span
+              className="inline-block h-3.5 w-3.5 rounded-full shrink-0"
+              style={{ backgroundColor: UNDERTONE_COLORS[tone] }}
+            />
+            {tone}
+          </Link>
+        ))}
+      </div>
+
+      {/* Color grid */}
+      <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {initialColors.map((color) => (
+          <ColorCard
+            key={color.id}
+            name={color.name}
+            hex={color.hex}
+            brandName={color.brand.name}
+            brandSlug={color.brand.slug}
+            colorSlug={color.slug}
+            colorNumber={color.color_number}
+          />
+        ))}
+      </div>
+
+      {/* Basic pagination — page 2 link if more colors exist */}
+      {totalPages > 1 && (
+        <nav className="mt-12 flex items-center justify-center gap-2">
+          <Link
+            href={`/colors/family/${familySlug}?page=2`}
+            className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors"
+          >
+            Next
+          </Link>
+        </nav>
+      )}
+    </>
+  );
+}

--- a/src/components/family-color-library.tsx
+++ b/src/components/family-color-library.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ColorCard } from "./color-card";
+
+interface Brand {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface FamilyColor {
+  id: string;
+  name: string;
+  slug: string;
+  hex: string;
+  color_number?: string | null;
+  brand: { name: string; slug: string };
+}
+
+interface Props {
+  familySlug: string;
+  familyName: string;
+  brands: Brand[];
+  initialColors: FamilyColor[];
+  initialTotalCount: number;
+}
+
+const UNDERTONE_COLORS: Record<string, string> = {
+  warm: "#E8B87D",
+  cool: "#7DA8CC",
+  neutral: "#B8B4AC",
+};
+
+const PER_PAGE = 60;
+
+export function FamilyColorLibrary({
+  familySlug,
+  familyName,
+  brands,
+  initialColors,
+  initialTotalCount,
+}: Props) {
+  const searchParams = useSearchParams();
+  const brandFilter = searchParams.get("brand") ?? "";
+  const undertoneFilter = searchParams.get("undertone") ?? "";
+  const pageParam = parseInt(searchParams.get("page") ?? "1", 10) || 1;
+  const currentPage = Math.max(1, pageParam);
+
+  const hasFilters = !!brandFilter || !!undertoneFilter || currentPage > 1;
+  const signature = `${brandFilter}|${undertoneFilter}|${currentPage}`;
+
+  const [fetched, setFetched] = useState<{
+    colors: FamilyColor[];
+    total: number;
+    signature: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Display the fetched data only when its signature matches the current
+  // URL filters; otherwise fall back to the server-rendered initial data.
+  // This avoids syncing initial-state into local state via useEffect (which
+  // would cascade unnecessary re-renders).
+  const usingFetched = hasFilters && fetched?.signature === signature;
+  const colors = usingFetched ? fetched.colors : initialColors;
+  const totalCount = usingFetched ? fetched.total : initialTotalCount;
+  const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
+
+  // setLoading + setFetched here reflect real async side-effects (kicking off
+  // a fetch and reflecting its lifecycle), not derived state syncing.
+  // The react-hooks/set-state-in-effect rule treats all in-effect updates
+  // as suspect, so we suppress for this specific block.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!hasFilters) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const p = new URLSearchParams();
+    if (brandFilter) p.set("brand", brandFilter);
+    if (undertoneFilter) p.set("undertone", undertoneFilter);
+    if (currentPage > 1) p.set("page", String(currentPage));
+
+    let cancelled = false;
+    fetch(`/api/family/${familySlug}/colors?${p.toString()}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (Array.isArray(data?.colors)) {
+          setFetched({
+            colors: data.colors,
+            total: data.totalCount ?? 0,
+            signature,
+          });
+        }
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [familySlug, hasFilters, signature, brandFilter, undertoneFilter, currentPage]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  function makeHref(opts: {
+    brand?: string | null;
+    undertone?: string | null;
+    page?: number;
+  }) {
+    const p = new URLSearchParams();
+    const b = opts.brand !== undefined ? opts.brand : brandFilter;
+    const u = opts.undertone !== undefined ? opts.undertone : undertoneFilter;
+    const pg = opts.page !== undefined ? opts.page : currentPage;
+    if (b) p.set("brand", b);
+    if (u) p.set("undertone", u);
+    if (pg && pg > 1) p.set("page", String(pg));
+    const qs = p.toString();
+    return `/colors/family/${familySlug}${qs ? `?${qs}` : ""}`;
+  }
+
+  const pages: (number | "ellipsis")[] = [];
+  if (totalPages > 1) {
+    const addPage = (n: number) => {
+      if (n >= 1 && n <= totalPages && !pages.includes(n)) pages.push(n);
+    };
+    addPage(1);
+    if (currentPage > 3) pages.push("ellipsis");
+    addPage(currentPage - 1);
+    addPage(currentPage);
+    addPage(currentPage + 1);
+    if (currentPage < totalPages - 2) pages.push("ellipsis");
+    addPage(totalPages);
+  }
+
+  return (
+    <>
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-8 mb-12">
+        <div>
+          <h2 className="font-headline text-4xl font-bold tracking-tight text-on-surface">
+            {familyName} Color Library
+          </h2>
+          <p className="text-outline mt-2">
+            {totalCount.toLocaleString()} colors
+            {brandFilter ? ` from ${brandFilter}` : ""}
+            {undertoneFilter ? ` · ${undertoneFilter} undertone` : ""}.
+          </p>
+        </div>
+      </div>
+
+      {/* Brand filter */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        <Link
+          href={makeHref({ brand: null, page: 1 })}
+          className={`rounded-full px-4 py-2 text-sm font-headline font-bold transition-all ${!brandFilter ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant hover:text-primary"}`}
+        >
+          All Brands
+        </Link>
+        {brands.map((b) => (
+          <Link
+            key={b.slug}
+            href={makeHref({ brand: b.slug, page: 1 })}
+            className={`rounded-full px-4 py-2 text-sm font-headline font-bold transition-all ${brandFilter === b.slug ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant hover:text-primary"}`}
+          >
+            {b.name}
+          </Link>
+        ))}
+      </div>
+
+      {/* Undertone filter */}
+      <div className="flex flex-wrap gap-2 mb-10">
+        <Link
+          href={makeHref({ undertone: null, page: 1 })}
+          className={`rounded-full px-4 py-2 text-sm transition-all flex items-center gap-2 ${!undertoneFilter ? "bg-secondary text-on-secondary font-bold" : "bg-surface-container-lowest text-on-surface-variant hover:text-secondary"}`}
+        >
+          All Undertones
+        </Link>
+        {(["warm", "cool", "neutral"] as const).map((tone) => (
+          <Link
+            key={tone}
+            href={makeHref({ undertone: tone, page: 1 })}
+            className={`rounded-full px-4 py-2 text-sm capitalize transition-all flex items-center gap-2 ${undertoneFilter === tone ? "bg-secondary text-on-secondary font-bold" : "bg-surface-container-lowest text-on-surface-variant hover:text-secondary"}`}
+          >
+            <span
+              className="inline-block h-3.5 w-3.5 rounded-full shrink-0"
+              style={{ backgroundColor: UNDERTONE_COLORS[tone] }}
+            />
+            {tone}
+          </Link>
+        ))}
+      </div>
+
+      {/* Color grid */}
+      <div
+        className={`grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 transition-opacity ${loading ? "opacity-50" : ""}`}
+      >
+        {colors.map((color) => (
+          <ColorCard
+            key={color.id}
+            name={color.name}
+            hex={color.hex}
+            brandName={color.brand.name}
+            brandSlug={color.brand.slug}
+            colorSlug={color.slug}
+            colorNumber={color.color_number}
+          />
+        ))}
+      </div>
+
+      {colors.length === 0 && !loading && (
+        <p className="mt-12 text-center text-on-surface-variant">
+          No {familyName.toLowerCase()} colors found
+          {brandFilter ? ` from this brand` : ""}.
+        </p>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <nav className="mt-12 flex items-center justify-center gap-2">
+          {currentPage > 1 && (
+            <Link
+              href={makeHref({ page: currentPage - 1 })}
+              className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors"
+            >
+              Previous
+            </Link>
+          )}
+          {pages.map((page, i) =>
+            page === "ellipsis" ? (
+              <span key={`e${i}`} className="px-2 text-outline">
+                ...
+              </span>
+            ) : (
+              <Link
+                key={page}
+                href={makeHref({ page })}
+                className={`rounded-xl px-4 py-2.5 text-sm font-headline font-bold transition-all ${page === currentPage ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant border border-outline-variant/15 hover:text-primary"}`}
+              >
+                {page}
+              </Link>
+            ),
+          )}
+          {currentPage < totalPages && (
+            <Link
+              href={makeHref({ page: currentPage + 1 })}
+              className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors"
+            >
+              Next
+            </Link>
+          )}
+        </nav>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

After PR #31 fixed color pages, family pages (\`/colors/family/[familySlug]\`) were still dynamic SSR every request — \`cache-control: private, no-store\`, \`x-vercel-cache: MISS\`. Root cause: Server Component reads \`await searchParams\` for filter/pagination state, which forces dynamic rendering in Next.js 16 regardless of generateStaticParams or revalidate.

## Architecture

Moves all filter and pagination interactivity to a client component. The Server Component reads zero searchParams.

\`\`\`
Server (page.tsx, static)
  ├─ Hero + breadcrumb + editorial intro     ← unchanged, server-rendered
  ├─ JSON-LD (CollectionPage, BreadcrumbList) ← unchanged
  ├─ Initial unfiltered page-1 colors (60)    ← server-fetched, passed as props
  └─ <FamilyColorLibrary> client component   ← handles all interactivity

Client (FamilyColorLibrary)
  ├─ useSearchParams() reads brand/undertone/page from URL
  ├─ If no filters → display server-rendered initial data
  └─ If filters → fetch /api/family/[slug]/colors?... and swap in result

API route (/api/family/[slug]/colors)
  ├─ Same getColorsByFamily / getColorsByFamilyCount queries as before
  └─ Cache-Control: public, max-age=3600, s-maxage=3600, swr=86400
\`\`\`

## Trade-offs

- **Bookmark/share-with-filter** still works — URL state drives the displayed grid via client-side fetch
- **Deep-link to filtered URL** (e.g. \`/colors/family/blue?brand=behr\`) shows unfiltered colors for ~50-150ms while the client fetch runs, then swaps to filtered. Acceptable since filtered variants are noindex'd via canonical anyway
- **Removed shouldNoindex meta-robots** logic (it was searchParams-derived, can't be set statically). Canonical now points to base URL on all variants, so Google consolidates filter variants to the canonical — same SEO outcome
- **TrackPage params** lose brand_filter/undertone_filter/page_number (those are now client-side state, not server-known)

## Test plan

- [ ] Preview build classifies \`/colors/family/[familySlug]\` as \`●\` (SSG/ISR) instead of \`ƒ\` (Dynamic). Check build log for the route summary.
- [ ] Curl preview: \`/colors/family/blue\` returns \`cache-control: public, max-age=0, must-revalidate\` + \`x-nextjs-prerender: 1\`
- [ ] Open \`/colors/family/blue\` in browser — colors render server-side (visible in view-source)
- [ ] Open \`/colors/family/blue?brand=behr\` — brief flash of unfiltered, then filtered
- [ ] Open \`/colors/family/blue?page=2\` — same flash-then-swap behavior, pagination links work
- [ ] Click filter pills — URL updates via \`<Link>\` navigation, grid refetches
- [ ] After merge: production curl shows \`x-vercel-cache: HIT\` on second request to \`/colors/family/blue\`

## Notes

- generateStaticParams unchanged — still pre-renders all 15 valid family slugs at build time
- API route signature lets \`getColorsByFamily\`/\`getColorsByFamilyCount\` stay unchanged
- Cache headers on the API match the existing \`/api/search\` route pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)