### PR TITLE
seo(match): rewrite H1 + title to match SERP query phrasing

### DIFF
--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -44,10 +44,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const url = `https://www.paintcolorhq.com/match/${sourceBrandSlug}/${parsed.colorSlug}-to-${parsed.targetBrandSlug}`;
   const variantMatch = parsed.colorSlug.match(/-([2-9])$/);
   const variant = variantMatch && !sourceColor.color_number?.toLowerCase().endsWith(variantMatch[1]) ? ` (variant ${variantMatch[1]})` : "";
-  const shortTitle = `${sourceColor.name}${variant} (${sourceColor.brand.name}) to ${targetBrand.name}`;
+  const colorNum = sourceColor.color_number ? ` ${sourceColor.color_number}` : "";
+  // Title pivots to the exact phrasing of the dominant PAA query
+  // ("What is the Behr equivalent of Agreeable Gray?") to lift CTR and
+  // align with the way Google surfaces "[Brand] equivalent of [color]" results.
+  const shortTitle = `${targetBrand.name} Equivalent of ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant}`;
   return {
     title: { absolute: shortTitle },
-    description: `${sourceColor.brand.name} ${sourceColor.name}${variant} (${sourceColor.hex.toUpperCase()}) to ${targetBrand.name}: ${note}. Compare hex, undertone, and LRV.`,
+    description: `Find the closest ${targetBrand.name} match for ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant} (${sourceColor.hex.toUpperCase()}). ${note}. Compare hex, LRV, and undertone side by side.`,
     alternates: { canonical: url },
     openGraph: { title: shortTitle, description: `Find the closest ${targetBrand.name} equivalent.`, url,
       images: [{ url: `/api/og?hex=${encodeURIComponent(sourceColor.hex)}&name=${encodeURIComponent(sourceColor.name)}&brand=${encodeURIComponent(`${sourceColor.brand.name} \u2192 ${targetBrand.name}`)}`, width: 1200, height: 630 }],
@@ -124,8 +128,11 @@ export default async function MatchPage({ params }: PageProps) {
         </nav>
 
         <h1 className="font-headline text-3xl md:text-4xl font-extrabold tracking-tight text-on-surface mb-4">
-          {sourceColor.brand.name} {sourceColor.name} in {targetBrand.name}
+          {targetBrand.name} Equivalent of {sourceColor.name}{sourceColor.color_number ? ` ${sourceColor.color_number}` : ""}
         </h1>
+        <p className="text-sm text-on-surface-variant mb-4">
+          Cross-brand match from {sourceColor.brand.name} {sourceColor.name} to {targetBrand.name}.
+        </p>
 
         {bestMatch ? (
           <>


### PR DESCRIPTION
## Summary

SXO audit finding: match page H1 reads \`"Sherwin-Williams Agreeable Gray in Behr"\` but the dominant PAA query is \`"What is the Behr equivalent of Agreeable Gray?"\`. Pages whose H1 + title mirror PAA phrasing get featured-snippet pulls more often.

## Changes

- **H1**: \`"Sherwin-Williams Agreeable Gray in Behr"\` → \`"Behr Equivalent of Agreeable Gray SW 7029"\`. Source-brand context preserved via a subtitle directly below the H1.
- **<title> + OG title**: same pivot. SERP snippet leads with \`"Behr Equivalent of Sherwin-Williams Agreeable Gray SW 7029"\`.
- **meta description**: action-oriented ("Find the closest Behr match for..." vs. generic "Compare hex, undertone, and LRV").
- **Color number** now included in title + H1 for color-code query CTR.

FAQPage JSON-LD was already phrased correctly ("What is the Behr equivalent of...") — no change needed.

## Test plan

- [x] tsc clean
- [x] eslint clean (pre-existing ColorSwatch unused warning unrelated)
- [ ] Preview deploy renders the new H1 correctly on a sample match URL
- [ ] SERP snippet pulled by Google reflects new title within a few days of indexing
- [ ] FAQ schema preserved (verify in https://search.google.com/test/rich-results)

## Note

This affects all ~24,950 individual match pages (one per color × target brand combination). Title + H1 are derived at request time, so the change applies immediately on deploy with no per-page editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)