### PR TITLE
seo(geo): add FAQPage JSON-LD to family pages + top blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -225,6 +225,22 @@ export default async function BlogPostPage({ params }: PageProps) {
           { "@type": "ListItem", position: 3, name: post.title, item: `https://www.paintcolorhq.com/blog/${post.slug}` },
         ],
       }} />
+      {/* FAQPage schema — for AI engine citation (Perplexity, AI Overviews,
+          ChatGPT). Google restricted FAQPage rich results to government/
+          healthcare in Aug 2023, so no Google SERP lift, but AI engines still
+          extract these Q&A pairs for citation. Only emitted when the post
+          defines a `faq` array. */}
+      {post.faq && post.faq.length > 0 && (
+        <JsonLd data={{
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: post.faq.map((item) => ({
+            "@type": "Question",
+            name: item.question,
+            acceptedAnswer: { "@type": "Answer", text: item.answer },
+          })),
+        }} />
+      )}
     </div>
   );
 }

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -97,6 +97,41 @@ export default async function ColorFamilyPage({ params }: PageProps) {
           ]},
         ],
       }} />
+      {/* FAQPage schema — primarily for AI engine citation (Perplexity, AI
+          Overviews, ChatGPT). Google restricted FAQPage rich results to
+          government/healthcare in Aug 2023, so commercial pages don't get
+          Google rich-result lift here, but the structured Q&A is still
+          consumed by AI search and lifts citation odds. */}
+      <JsonLd data={{
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: [
+          {
+            "@type": "Question",
+            name: `How many ${familyName.toLowerCase()} paint colors are catalogued?`,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: `Paint Color HQ catalogs ${totalCount.toLocaleString()} ${familyName.toLowerCase()} paint colors across ${brandCount} major brands, including Sherwin-Williams, Benjamin Moore, Behr, Valspar, PPG, Dunn-Edwards, and Farrow & Ball.`,
+            },
+          },
+          {
+            "@type": "Question",
+            name: `What undertones do ${familyName.toLowerCase()} paint colors have?`,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: `${familyName} paint colors come in warm undertones (leaning yellower, redder, or browner), cool undertones (leaning bluer or greener), and balanced neutrals. Use the undertone filter on this page to narrow your search to warm, cool, or neutral options.`,
+            },
+          },
+          {
+            "@type": "Question",
+            name: `How do I find a ${familyName.toLowerCase()} paint color that matches across brands?`,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: `Every color page on Paint Color HQ shows cross-brand matches ranked by CIEDE2000 Delta E score. Colors with a Delta E under 2.0 are virtually identical on a finished wall. Click any color in the grid above to see its closest matches across all ${brandCount} brands.`,
+            },
+          },
+        ],
+      }} />
       <TrackPage eventName="page_view_enriched" params={{ page_type: "family", color_family: familySlug, result_count: totalCount }} />
       <Header />
 

--- a/src/lib/blog-posts.tsx
+++ b/src/lib/blog-posts.tsx
@@ -18,6 +18,11 @@ export interface BlogPost {
   tags: string[];
   noindex?: boolean; // true = exclude from sitemap and add noindex meta
   content: () => ReactNode;
+  // Optional FAQ items emitted as FAQPage JSON-LD for AI engine citation
+  // (Perplexity, AI Overviews, ChatGPT). Google restricted FAQPage rich
+  // results to government/healthcare in Aug 2023, so this won't surface
+  // a rich result on Google SERPs but does help AI engines extract Q&A.
+  faq?: Array<{ question: string; answer: string }>;
 }
 
 /* ------------------------------------------------------------------ */
@@ -772,6 +777,28 @@ const blogPosts: BlogPost[] = [
     coverColor: "#6B8F71",
     coverImage: "/blog/how-to-find-perfect-color-match-across-brands.webp",
     tags: ["How-To", "Cross-Brand Matching", "Color Science"],
+    faq: [
+      {
+        question: "What is Delta E in paint matching?",
+        answer:
+          "Delta E (ΔE) is a numeric score that measures perceived color difference. Paint Color HQ uses the CIEDE2000 revision, the international color-science standard. ΔE under 1.0 is virtually indistinguishable, ΔE 1.0-2.0 is a very close match most people won't notice, ΔE 2.0-3.0 is close but perceptible at a glance, and ΔE above 5.0 is clearly different colors.",
+      },
+      {
+        question: "How accurate are cross-brand paint color matches?",
+        answer:
+          "Cross-brand matches under ΔE 2.0 are virtually identical on a finished wall — most homeowners won't perceive the difference. The vast majority of popular colors from major brands (Sherwin-Williams, Benjamin Moore, Behr, Valspar, PPG) have at least one cross-brand match within ΔE 2.0 in our database.",
+      },
+      {
+        question: "Should I trust a custom-mixed paint match over a catalog match?",
+        answer:
+          "A formulated catalog color is usually more reliable. In-store spectrophotometers drift between calibrations, producing ΔE errors of 2.0-5.0 on a single scan, and custom mixes carry batch-to-batch variation that complicates touch-ups years later. Standard catalog colors are formulated to ΔE under 0.5 batch-to-batch.",
+      },
+      {
+        question: "What's the best way to verify a paint color match in person?",
+        answer:
+          "Buy sample pots of both the original and the proposed match. Paint at least 12×12-inch swatches side-by-side on the same wall, then view them at four times of day: early morning, midday with direct sun, late afternoon, and nighttime under artificial light. Color shifts in different lighting often reveal differences that aren't visible on a chip.",
+      },
+    ],
     content: () => (
       <>
         <p className="text-lg leading-relaxed text-gray-800">
@@ -2614,6 +2641,28 @@ const blogPosts: BlogPost[] = [
     coverColor: "#C8C0B4",
     coverImage: "/blog/paint-sheen-guide.webp",
     tags: ["Guide", "Tips", "Beginner"],
+    faq: [
+      {
+        question: "What paint sheen should I use for a bedroom?",
+        answer:
+          "Eggshell is the standard for adult bedrooms — soft, slightly washable, hides minor wall imperfections. Use flat or matte for ceilings. Kids' bedrooms benefit from satin or eggshell for easier cleanup of fingerprints and crayon.",
+      },
+      {
+        question: "What sheen for kitchens and bathrooms?",
+        answer:
+          "Satin or semi-gloss for kitchen and bathroom walls — both are moisture-resistant and easy to clean. Eggshell can work in dry, well-ventilated bathrooms but won't hold up over a shower. For trim, use semi-gloss in both rooms.",
+      },
+      {
+        question: "What sheen for trim, doors, and baseboards?",
+        answer:
+          "Semi-gloss is standard for trim and doors — it's durable enough to handle frequent contact and easy to wipe clean. The slight contrast in sheen between walls (eggshell) and trim (semi-gloss) is what gives a room its crisp finished look. High-gloss is reserved for accent doors, cabinets, or trim where you want maximum shine.",
+      },
+      {
+        question: "Does sheen affect how a paint color looks?",
+        answer:
+          "Yes. The same color looks slightly different across sheens. Higher sheens reflect more light, making colors appear marginally lighter and more saturated. Flat absorbs light and produces the richest, deepest color appearance. When comparing colors across brands, always compare the same sheen level.",
+      },
+    ],
     content: () => (
       <>
         <p className="text-lg leading-relaxed text-gray-800">


### PR DESCRIPTION
## Summary

GEO audit recommended adding FAQPage schema to family pages and high-traffic blog posts for AI engine citation (Perplexity, Google AI Overviews, ChatGPT). Google restricted FAQPage rich results to government/healthcare in Aug 2023 — so this won't unlock a Google SERP rich result on commercial pages — but AI engines still extract Q&A pairs and citation odds increase materially when the schema is present.

## Changes

**Family pages (all 15 slugs):** 3 data-parameterized FAQ items per family.
- "How many [family] paint colors are catalogued?" — references live \`totalCount\`
- "What undertones do [family] paint colors have?" — points at the undertone filter
- "How do I find a [family] color that matches across brands?" — references live \`brandCount\` and Delta E methodology

All answers use the page's actual count values so the schema stays accurate per family.

**BlogPost type:** added optional \`faq?: Array<{question, answer}>\` field. The blog page template (\`/src/app/blog/[slug]/page.tsx\`) emits FAQPage JSON-LD only when the post defines \`faq\` — so rollout can be incremental.

**Two starter blog posts get FAQ:**
- \`how-to-find-perfect-color-match-across-brands\` — 4 Q&A on Delta E, match accuracy, custom-mix vs catalog, physical-sample verification
- \`paint-sheen-guide\` — 4 Q&A on bedroom, kitchen, trim sheen choices + sheen-color interaction

## Impact

**17 pages** now emit FAQPage schema for AI engines. Additional blog posts can opt in by adding a \`faq\` field to their definition — no template changes needed.

## Notes

- The audit was clear that FAQPage on commercial pages won't earn Google rich results. That's expected. The win is AI engine citation, which is the dominant driver of the site's GEO score.
- Visible FAQ accordion sections on family pages would compound the benefit but require UI work; left for a follow-up.
- The match page already had FAQPage schema (per the existing implementation) and is unchanged.

## Test plan

- [x] tsc clean
- [x] eslint clean (pre-existing img warnings unrelated)
- [ ] Validate the family-page FAQPage at https://search.google.com/test/rich-results
- [ ] Validate one blog FAQPage at the same tool
- [ ] After merge, watch for AI Overview / Perplexity citations referencing the FAQ answers in 2-4 weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)