### PR TITLE
seo(internal-link): bridge color→blog and family→inspiration clusters

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -491,6 +491,29 @@ export default async function ColorPage({ params }: PageProps) {
         </div>
       </section>
 
+      {/* Related Reading — closes the color -> blog cluster gap the audit
+          flagged. Universal links to high-relevance editorial guides. */}
+      <section className="max-w-7xl mx-auto px-6 md:px-12 pb-16">
+        <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-8">Related Reading</h2>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <Link href="/blog/how-to-find-perfect-color-match-across-brands" className="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all duration-500">
+            <p className="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">How to Match Paint Colors Across Brands</p>
+            <p className="mt-2 text-sm text-on-surface-variant leading-relaxed">The science behind Delta E and CIEDE2000 — find a Behr equivalent of any Sherwin-Williams shade, or a Benjamin Moore alternative when your store is out of stock.</p>
+          </Link>
+          {color.undertone ? (
+            <Link href="/blog/understanding-paint-color-undertones" className="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all duration-500">
+              <p className="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">Understanding Paint Color Undertones</p>
+              <p className="mt-2 text-sm text-on-surface-variant leading-relaxed">Why {color.name}&apos;s {color.undertone.toLowerCase()} undertone matters more than its surface color — and how to read undertones in any paint chip.</p>
+            </Link>
+          ) : (
+            <Link href="/blog/paint-sheen-guide" className="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all duration-500">
+              <p className="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">Paint Sheen Guide</p>
+              <p className="mt-2 text-sm text-on-surface-variant leading-relaxed">Flat, eggshell, satin, or semi-gloss — the right finish for {color.name} depends on the room. Here&apos;s how to choose.</p>
+            </Link>
+          )}
+        </div>
+      </section>
+
       {/* JSON-LD — Product schema for color detail */}
       <JsonLd data={{
         "@context": "https://schema.org",

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -7,7 +7,8 @@ import { Footer } from "@/components/footer";
 import { FamilyColorLibrary } from "@/components/family-color-library";
 import { FamilyColorLibraryFallback } from "@/components/family-color-library-fallback";
 import { getColorsByFamily, getColorsByFamilyCount, getAllBrands } from "@/lib/queries";
-import { getFamilyContent } from "@/lib/family-content";
+import { getFamilyContent, getFamilyRelatedPalettes } from "@/lib/family-content";
+import { getPaletteBySlug } from "@/lib/palettes";
 import { TrackPage } from "@/components/track-page";
 import { ColorLinkEnhancer } from "@/components/color-link-enhancer";
 
@@ -197,6 +198,56 @@ export default async function ColorFamilyPage({ params }: PageProps) {
           </div>
         </div>
       </section>
+
+      {/* Inspiration Featuring [Family] — closes the family -> inspiration
+          cluster gap the audit flagged. Cards link to curated palettes that
+          prominently feature this color family. */}
+      {(() => {
+        const relatedSlugs = getFamilyRelatedPalettes(familySlug);
+        const relatedPalettes = relatedSlugs
+          .map((slug) => getPaletteBySlug(slug))
+          .filter((p): p is NonNullable<typeof p> => p !== undefined);
+        if (relatedPalettes.length === 0) return null;
+        return (
+          <section className="py-20 px-6 md:px-12 bg-surface-container-low">
+            <div className="max-w-7xl mx-auto">
+              <h2 className="font-headline text-3xl font-bold text-on-surface tracking-tight mb-2">
+                Inspiration Featuring {familyName}
+              </h2>
+              <p className="text-on-surface-variant mb-8 max-w-2xl">
+                Curated palettes where {familyName.toLowerCase()} plays a leading role — see how designers pair these colors in real rooms.
+              </p>
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {relatedPalettes.map((p) => (
+                  <Link
+                    key={p.slug}
+                    href={`/inspiration/${p.slug}`}
+                    className="group block overflow-hidden rounded-xl bg-surface-container-lowest border border-outline-variant/10 transition-all hover:shadow-lg"
+                  >
+                    <div className="flex h-24 w-full">
+                      {p.colors.map((hex, i) => (
+                        <div
+                          key={i}
+                          className="flex-1"
+                          style={{ backgroundColor: hex }}
+                        />
+                      ))}
+                    </div>
+                    <div className="p-5">
+                      <p className="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">
+                        {p.name}
+                      </p>
+                      <p className="mt-2 text-sm text-on-surface-variant leading-relaxed">
+                        {p.description}
+                      </p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </section>
+        );
+      })()}
 
       <Footer />
     </div>

--- a/src/lib/family-content.tsx
+++ b/src/lib/family-content.tsx
@@ -695,6 +695,33 @@ const content: Record<string, FamilyContent> = {
   },
 };
 
+// Maps each family slug to 2-3 inspiration palette slugs whose color
+// composition naturally features that family. Used by the family page
+// to surface contextual inspiration cards — closes the cluster gap
+// flagged by the audit where family pages had zero outbound links to
+// inspiration palettes despite obvious thematic alignment.
+const familyRelatedPalettes: Record<string, string[]> = {
+  white: ["modern-farmhouse", "scandinavian-minimal", "soft-romantic"],
+  "off-white": ["modern-farmhouse", "scandinavian-minimal", "french-country"],
+  gray: ["modern-farmhouse", "scandinavian-minimal", "urban-industrial"],
+  beige: ["modern-farmhouse", "earthy-organic", "french-country"],
+  tan: ["french-country", "classic-traditional", "modern-farmhouse"],
+  brown: ["earthy-organic", "woodland-cabin", "desert-sunset"],
+  black: ["midnight-luxe", "urban-industrial", "moody-library"],
+  blue: ["coastal-retreat", "ocean-breeze", "moody-library"],
+  green: ["earthy-organic", "woodland-cabin", "spring-garden"],
+  red: ["bold-and-eclectic", "tropical-escape", "classic-traditional"],
+  orange: ["desert-sunset", "mediterranean-sun", "tropical-escape"],
+  yellow: ["spring-garden", "tropical-escape", "mediterranean-sun"],
+  pink: ["soft-romantic", "vintage-charm", "spring-garden"],
+  purple: ["midnight-luxe", "vintage-charm"],
+  neutral: ["modern-farmhouse", "scandinavian-minimal", "french-country"],
+};
+
+export function getFamilyRelatedPalettes(slug: string): string[] {
+  return familyRelatedPalettes[slug] ?? [];
+}
+
 export function getFamilyContent(slug: string): FamilyContent | undefined {
   return content[slug];
 }


### PR DESCRIPTION
## Summary

The cluster audit identified two HIGH-priority internal-link gaps the rest of today's PRs didn't address:

1. **Color detail pages link to tools but never to editorial blog content** — missing the color → blog → tool funnel.
2. **Family hub pages link to other families and tools but not to thematically matching inspiration pages.** Zero family → inspiration links exist in body content despite obvious topic alignment (blue belongs in coastal palettes, gray in modern-farmhouse, etc.).

## Changes

### Color detail page — new "Related Reading" section

Two cards below the existing "Explore More" tools section:
- Always-shown: "How to Match Paint Colors Across Brands" (CIEDE2000/Delta E guide)
- Color-aware: "Understanding Paint Color Undertones" when \`color.undertone\` exists, with copy that references this specific color's undertone. Falls back to "Paint Sheen Guide" otherwise.

### Family page — new "Inspiration Featuring [Family]" section

Cards link to 2-3 curated palettes that prominently feature the color family. Mapping defined in \`src/lib/family-content.tsx\` as \`familyRelatedPalettes\`:

| Family | Linked palettes |
|---|---|
| blue | coastal-retreat, ocean-breeze, moody-library |
| gray | modern-farmhouse, scandinavian-minimal, urban-industrial |
| green | earthy-organic, woodland-cabin, spring-garden |
| white | modern-farmhouse, scandinavian-minimal, soft-romantic |
| ... | (all 15 valid family slugs mapped) |

Cards render the palette's 5-color stripe + name + description (no new component needed).

## Impact

- **~25,000 color detail pages** gain 2 contextual blog links each
- **15 family pages** surface 2-3 inspiration palette cards each
- Closes both audit-flagged cluster bridges
- No schema, no API, no new components — just template additions + a small data mapping

## Test plan

- [x] tsc clean
- [x] eslint clean (pre-existing img + ColorSwatch warnings unrelated)
- [ ] Preview deploy renders both new sections on sample color/family pages
- [ ] Confirm palette cards render correctly across 3-4 different families
- [ ] Confirm the undertone-vs-sheen blog card branching works (test a color with undertone and one without)

🤖 Generated with [Claude Code](https://claude.com/claude-code)