### PR TITLE
seo(sitemap): add lastmod, drop ignored fields, include author page

### DIFF
--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -6,13 +6,21 @@ import { inspirationPalettes } from "@/lib/palettes";
 const BASE_URL = "https://www.paintcolorhq.com";
 const COLORS_PER_SITEMAP = 5000;
 
+// Build-time date used as the default lastmod for sitemap entries whose
+// content doesn't have a per-row timestamp (brands, colors, families,
+// matches, inspiration). Evaluated at module load — for serverless cold
+// starts this is effectively "deploy time," which is what we want
+// Googlebot to see as the recency signal. Blog posts use their own
+// post.date and override this.
+const SITE_BUILD_DATE = new Date().toISOString().split("T")[0];
+
 interface SitemapEntry {
   url: string;
-  priority: string;
-  changefreq: string;
   lastmod: string;
 }
 
+// Google ignores <changefreq> and <priority>, so they're omitted. Only
+// <loc> and <lastmod> are emitted per URL.
 function buildSitemapXml(entries: SitemapEntry[]): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -20,8 +28,6 @@ ${entries
   .map(
     (entry) => `  <url>
     <loc>${BASE_URL}${entry.url}</loc>${entry.lastmod ? `\n    <lastmod>${entry.lastmod}</lastmod>` : ""}
-    <changefreq>${entry.changefreq}</changefreq>
-    <priority>${entry.priority}</priority>
   </url>`
   )
   .join("\n")}
@@ -39,31 +45,30 @@ export async function GET(
 
     if (id === "pages") {
       entries = [
-        { url: "/", priority: "1.0", changefreq: "weekly", lastmod: "" },
-        { url: "/brands", priority: "0.8", changefreq: "weekly", lastmod: "" },
-        { url: "/colors", priority: "0.8", changefreq: "weekly", lastmod: "" },
-        { url: "/search", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/compare", priority: "0.6", changefreq: "monthly", lastmod: "" },
-        { url: "/blog", priority: "0.7", changefreq: "weekly", lastmod: "" },
-        { url: "/inspiration", priority: "0.7", changefreq: "weekly", lastmod: "" },
-        { url: "/tools", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/tools/paint-calculator", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/tools/color-identifier", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/tools/room-visualizer", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/tools/palette-generator", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/about", priority: "0.5", changefreq: "monthly", lastmod: "" },
-        { url: "/contact", priority: "0.5", changefreq: "monthly", lastmod: "" },
-        { url: "/faq", priority: "0.7", changefreq: "monthly", lastmod: "" },
-        { url: "/privacy", priority: "0.3", changefreq: "monthly", lastmod: "" },
-        { url: "/terms", priority: "0.3", changefreq: "monthly", lastmod: "" },
+        { url: "/", lastmod: SITE_BUILD_DATE },
+        { url: "/brands", lastmod: SITE_BUILD_DATE },
+        { url: "/colors", lastmod: SITE_BUILD_DATE },
+        { url: "/search", lastmod: SITE_BUILD_DATE },
+        { url: "/compare", lastmod: SITE_BUILD_DATE },
+        { url: "/blog", lastmod: SITE_BUILD_DATE },
+        { url: "/inspiration", lastmod: SITE_BUILD_DATE },
+        { url: "/tools", lastmod: SITE_BUILD_DATE },
+        { url: "/tools/paint-calculator", lastmod: SITE_BUILD_DATE },
+        { url: "/tools/color-identifier", lastmod: SITE_BUILD_DATE },
+        { url: "/tools/room-visualizer", lastmod: SITE_BUILD_DATE },
+        { url: "/tools/palette-generator", lastmod: SITE_BUILD_DATE },
+        { url: "/about", lastmod: SITE_BUILD_DATE },
+        { url: "/contact", lastmod: SITE_BUILD_DATE },
+        { url: "/faq", lastmod: SITE_BUILD_DATE },
+        { url: "/privacy", lastmod: SITE_BUILD_DATE },
+        { url: "/terms", lastmod: SITE_BUILD_DATE },
+        { url: "/authors/paint-color-hq-staff", lastmod: SITE_BUILD_DATE },
       ];
     } else if (id === "brands") {
       const brands = await getAllBrands();
       entries = brands.map((b) => ({
         url: `/brands/${b.slug}`,
-        priority: "0.8",
-        changefreq: "weekly",
-        lastmod: "",
+        lastmod: SITE_BUILD_DATE,
       }));
     } else if (id.startsWith("colors-")) {
       const pageNum = Number(id.slice("colors-".length));
@@ -78,9 +83,7 @@ export async function GET(
       }
       entries = pageColors.map((c) => ({
         url: `/colors/${c.brandSlug}/${c.colorSlug}`,
-        priority: "0.6",
-        changefreq: "monthly",
-        lastmod: "",
+        lastmod: SITE_BUILD_DATE,
       }));
     } else if (id === "matches") {
       // Brand-to-brand match landing pages — only major brand combinations
@@ -91,34 +94,30 @@ export async function GET(
           if (source !== target) {
             entries.push({
               url: `/match/${source}/to/${target}`,
-              priority: "0.8",
-              changefreq: "weekly",
-              lastmod: "",
+              lastmod: SITE_BUILD_DATE,
             });
           }
         }
       }
     } else if (id === "blog") {
-      entries = getAllBlogSlugs().map((s) => ({
-        url: `/blog/${s}`,
-        priority: "0.7",
-        changefreq: "monthly",
-        lastmod: getPostBySlug(s)?.date ?? "",
-      }));
+      entries = getAllBlogSlugs().map((s) => {
+        const post = getPostBySlug(s);
+        return {
+          url: `/blog/${s}`,
+          // Prefer modifiedDate, fall back to date, fall back to build date
+          lastmod: post?.modifiedDate ?? post?.date ?? SITE_BUILD_DATE,
+        };
+      });
     } else if (id === "families") {
       const families = await getAllColorFamilies();
       entries = families.map((f) => ({
         url: `/colors/family/${f.slug}`,
-        priority: "0.7",
-        changefreq: "weekly",
-        lastmod: "",
+        lastmod: SITE_BUILD_DATE,
       }));
     } else if (id === "inspiration") {
       entries = inspirationPalettes.map((p) => ({
         url: `/inspiration/${p.slug}`,
-        priority: "0.6",
-        changefreq: "weekly",
-        lastmod: "",
+        lastmod: SITE_BUILD_DATE,
       }));
     } else {
       return new NextResponse("Not found", { status: 404 });


### PR DESCRIPTION
## Summary

Three small audit follow-ups bundled into the sitemap route.

| Change | Why |
|---|---|
| Add \`lastmod\` to every entry | Pre-change, only blog had \`lastmod\` (from \`post.date\`); brands, colors, families, matches, inspiration all emitted empty tags. Without a freshness signal on 23k+ URLs, Googlebot has no signal to prioritize re-crawl. |
| Drop \`<changefreq>\` and \`<priority>\` | Google ignores both. Noise on every URL across all shards. |
| Add \`/authors/paint-color-hq-staff\` to pages sitemap | Author page is indexable but was sitemap-absent. \`BlogPosting.author\` URL now has a referent in the sitemap, which helps E-E-A-T discoverability. |

## Implementation

- New \`SITE_BUILD_DATE\` constant evaluated at module load — effectively "deploy time" on serverless cold starts. Used as lastmod fallback for everything except blog (which uses \`modifiedDate ?? date\`).
- \`SitemapEntry\` interface trimmed to \`{ url, lastmod }\`.
- Per-URL XML drops from 4 tags to 2 (\`<loc>\`, \`<lastmod>\`). For colors-N shards (5000 URLs each) this trims ~30% off response body size.

## Test plan

- [x] tsc clean, lint clean
- [ ] After deploy: \`curl https://www.paintcolorhq.com/sitemap/colors-0.xml | head -20\` shows \`<lastmod>\` on every entry, no \`<changefreq>\` or \`<priority>\`
- [ ] Confirm \`/authors/paint-color-hq-staff\` appears in pages sitemap
- [ ] Google Search Console: re-submit sitemap (or wait for next crawl) to pick up lastmod signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)