### PR TITLE
seo(sitemap): add match-individual shard for popular cross-brand matches

### DIFF
--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAllColorSlugs, getAllBrands, getAllColorFamilies } from "@/lib/queries";
 import { getAllBlogSlugs, getPostBySlug } from "@/lib/blog-posts";
 import { inspirationPalettes } from "@/lib/palettes";
+import { POPULAR_COLOR_SLUGS, MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
 
 const BASE_URL = "https://www.paintcolorhq.com";
 const COLORS_PER_SITEMAP = 5000;
@@ -84,7 +85,6 @@ export async function GET(
       }));
     } else if (id === "matches") {
       // Brand-to-brand match landing pages — only major brand combinations
-      const MAJOR_MATCH_BRANDS = ["sherwin-williams", "benjamin-moore", "behr", "ppg", "valspar"];
       entries = [];
       for (const source of MAJOR_MATCH_BRANDS) {
         for (const target of MAJOR_MATCH_BRANDS) {
@@ -96,6 +96,26 @@ export async function GET(
               lastmod: "",
             });
           }
+        }
+      }
+    } else if (id === "match-individual") {
+      // Individual cross-brand match pages for popular source colors. Each
+      // popular color emits one URL per major target brand (excluding self).
+      // ~47 source colors × 4–5 target brands = ~200 URLs in a single shard,
+      // well under the 50,000 sitemap limit. Non-popular colors' match pages
+      // still exist and are discoverable via internal links from color detail
+      // pages; sitemap inclusion is limited to the popular set to focus
+      // crawl budget on the highest-value cross-brand matches.
+      entries = [];
+      for (const { brandSlug, colorSlug } of POPULAR_COLOR_SLUGS) {
+        for (const target of MAJOR_MATCH_BRANDS) {
+          if (target === brandSlug) continue;
+          entries.push({
+            url: `/match/${brandSlug}/${colorSlug}-to-${target}`,
+            priority: "0.7",
+            changefreq: "monthly",
+            lastmod: "",
+          });
         }
       }
     } else if (id === "blog") {

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -14,6 +14,7 @@ export async function GET() {
       "pages",
       "brands",
       "matches",
+      "match-individual",
       ...Array.from({ length: totalColorSitemaps }, (_, i) => `colors-${i}`),
       "blog",
       "families",

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -18,6 +18,7 @@ import { getRetailerLinks } from "@/lib/retailer-links";
 import { TrackPage } from "@/components/track-page";
 import { TrackedLink } from "@/components/tracked-link";
 import { PairingSelector } from "@/components/pairing-selector";
+import { POPULAR_COLOR_SLUGS } from "@/lib/popular-colors";
 
 export const revalidate = 3600;
 
@@ -27,64 +28,8 @@ export const revalidate = 3600;
 // dynamic route segments — `revalidate` alone does not opt in.
 // https://nextjs.org/docs/app/api-reference/functions/generate-static-params#dynamic-segments-without-generatestaticparams
 //
-// Slug source: src/lib/brand-content.tsx + src/lib/family-content.tsx
-// (only slugs in active code, so they're known to match the database).
-const POPULAR_COLOR_SLUGS: Array<{ brandSlug: string; colorSlug: string }> = [
-  // Sherwin-Williams
-  { brandSlug: "sherwin-williams", colorSlug: "agreeable-gray-7029" },
-  { brandSlug: "sherwin-williams", colorSlug: "alabaster-7008" },
-  { brandSlug: "sherwin-williams", colorSlug: "naval-6244" },
-  { brandSlug: "sherwin-williams", colorSlug: "pure-white-7005" },
-  { brandSlug: "sherwin-williams", colorSlug: "repose-gray-7015" },
-  { brandSlug: "sherwin-williams", colorSlug: "cavern-clay-7701" },
-  { brandSlug: "sherwin-williams", colorSlug: "fireworks-6867" },
-  { brandSlug: "sherwin-williams", colorSlug: "grounded-6089" },
-  { brandSlug: "sherwin-williams", colorSlug: "quaint-coral-6536" },
-  { brandSlug: "sherwin-williams", colorSlug: "tricorn-black-6258" },
-  // Benjamin Moore
-  { brandSlug: "benjamin-moore", colorSlug: "chantilly-lace-oc-65" },
-  { brandSlug: "benjamin-moore", colorSlug: "edgecomb-gray-hc-173" },
-  { brandSlug: "benjamin-moore", colorSlug: "hale-navy-hc-154" },
-  { brandSlug: "benjamin-moore", colorSlug: "revere-pewter-hc-172" },
-  { brandSlug: "benjamin-moore", colorSlug: "simply-white-oc-117" },
-  { brandSlug: "benjamin-moore", colorSlug: "white-dove-oc-17" },
-  { brandSlug: "benjamin-moore", colorSlug: "burnt-caramel-2167-10" },
-  { brandSlug: "benjamin-moore", colorSlug: "caliente-af-290" },
-  { brandSlug: "benjamin-moore", colorSlug: "cinnamon-slate-2113-40" },
-  { brandSlug: "benjamin-moore", colorSlug: "hawthorne-yellow-hc-4" },
-  { brandSlug: "benjamin-moore", colorSlug: "wrought-iron-2124-10" },
-  // Behr
-  { brandSlug: "behr", colorSlug: "cameo-white-w-d-200" },
-  { brandSlug: "behr", colorSlug: "dolphin-fin-790c-3" },
-  { brandSlug: "behr", colorSlug: "silver-drop-790c-2" },
-  { brandSlug: "behr", colorSlug: "ultra-pure-white-1850" },
-  { brandSlug: "behr", colorSlug: "whisper-white-w-d-300" },
-  { brandSlug: "behr", colorSlug: "red-pepper-ppu2-02" },
-  // Dunn-Edwards
-  { brandSlug: "dunn-edwards", colorSlug: "bone-china-dew339" },
-  { brandSlug: "dunn-edwards", colorSlug: "cold-water-de6316" },
-  { brandSlug: "dunn-edwards", colorSlug: "cottage-white-dew318" },
-  { brandSlug: "dunn-edwards", colorSlug: "foggy-day-de6226" },
-  { brandSlug: "dunn-edwards", colorSlug: "swiss-coffee-dew341" },
-  // Farrow & Ball
-  { brandSlug: "farrow-ball", colorSlug: "ammonite-274" },
-  { brandSlug: "farrow-ball", colorSlug: "cornforth-white-228" },
-  { brandSlug: "farrow-ball", colorSlug: "elephants-breath-229" },
-  { brandSlug: "farrow-ball", colorSlug: "hague-blue-30" },
-  { brandSlug: "farrow-ball", colorSlug: "stiffkey-blue-281" },
-  // PPG
-  { brandSlug: "ppg", colorSlug: "delicate-white-1001-1" },
-  { brandSlug: "ppg", colorSlug: "gypsum-1006-1" },
-  { brandSlug: "ppg", colorSlug: "olive-sprig-1125-4" },
-  { brandSlug: "ppg", colorSlug: "stonehenge-greige-1024-5" },
-  { brandSlug: "ppg", colorSlug: "swirling-smoke-1007-2" },
-  // Valspar
-  { brandSlug: "valspar", colorSlug: "gravity-4005-1b" },
-  { brandSlug: "valspar", colorSlug: "gray-silt-6002-1c" },
-  { brandSlug: "valspar", colorSlug: "notre-dame-5006-1b" },
-  { brandSlug: "valspar", colorSlug: "safari-beige-6006-2b" },
-  { brandSlug: "valspar", colorSlug: "warm-eucalyptus-8004-28f" },
-];
+// POPULAR_COLOR_SLUGS lives in src/lib/popular-colors.ts so it can be
+// shared with the sitemap match-individual shard.
 
 export async function generateStaticParams() {
   // Verify each slug exists in the database before claiming it as a static

--- a/src/lib/popular-colors.ts
+++ b/src/lib/popular-colors.ts
@@ -1,0 +1,82 @@
+// Curated list of popular paint color slugs across major brands. Used by:
+// - src/app/colors/[brandSlug]/[colorSlug]/page.tsx — generateStaticParams,
+//   so these slugs are pre-rendered at build time.
+// - src/app/api/sitemap/[id]/route.ts — match-individual shard, so the
+//   cross-brand match pages for these colors are discoverable in the
+//   sitemap.
+//
+// Slug source: src/lib/brand-content.tsx + src/lib/family-content.tsx
+// (only slugs in active code, so they're known to match the database).
+// Each slug is verified against the DB at color page build time so a
+// stale entry doesn't break the build — see generateStaticParams in
+// the color detail page.
+export const POPULAR_COLOR_SLUGS: Array<{
+  brandSlug: string;
+  colorSlug: string;
+}> = [
+  // Sherwin-Williams
+  { brandSlug: "sherwin-williams", colorSlug: "agreeable-gray-7029" },
+  { brandSlug: "sherwin-williams", colorSlug: "alabaster-7008" },
+  { brandSlug: "sherwin-williams", colorSlug: "naval-6244" },
+  { brandSlug: "sherwin-williams", colorSlug: "pure-white-7005" },
+  { brandSlug: "sherwin-williams", colorSlug: "repose-gray-7015" },
+  { brandSlug: "sherwin-williams", colorSlug: "cavern-clay-7701" },
+  { brandSlug: "sherwin-williams", colorSlug: "fireworks-6867" },
+  { brandSlug: "sherwin-williams", colorSlug: "grounded-6089" },
+  { brandSlug: "sherwin-williams", colorSlug: "quaint-coral-6536" },
+  { brandSlug: "sherwin-williams", colorSlug: "tricorn-black-6258" },
+  // Benjamin Moore
+  { brandSlug: "benjamin-moore", colorSlug: "chantilly-lace-oc-65" },
+  { brandSlug: "benjamin-moore", colorSlug: "edgecomb-gray-hc-173" },
+  { brandSlug: "benjamin-moore", colorSlug: "hale-navy-hc-154" },
+  { brandSlug: "benjamin-moore", colorSlug: "revere-pewter-hc-172" },
+  { brandSlug: "benjamin-moore", colorSlug: "simply-white-oc-117" },
+  { brandSlug: "benjamin-moore", colorSlug: "white-dove-oc-17" },
+  { brandSlug: "benjamin-moore", colorSlug: "burnt-caramel-2167-10" },
+  { brandSlug: "benjamin-moore", colorSlug: "caliente-af-290" },
+  { brandSlug: "benjamin-moore", colorSlug: "cinnamon-slate-2113-40" },
+  { brandSlug: "benjamin-moore", colorSlug: "hawthorne-yellow-hc-4" },
+  { brandSlug: "benjamin-moore", colorSlug: "wrought-iron-2124-10" },
+  // Behr
+  { brandSlug: "behr", colorSlug: "cameo-white-w-d-200" },
+  { brandSlug: "behr", colorSlug: "dolphin-fin-790c-3" },
+  { brandSlug: "behr", colorSlug: "silver-drop-790c-2" },
+  { brandSlug: "behr", colorSlug: "ultra-pure-white-1850" },
+  { brandSlug: "behr", colorSlug: "whisper-white-w-d-300" },
+  { brandSlug: "behr", colorSlug: "red-pepper-ppu2-02" },
+  // Dunn-Edwards
+  { brandSlug: "dunn-edwards", colorSlug: "bone-china-dew339" },
+  { brandSlug: "dunn-edwards", colorSlug: "cold-water-de6316" },
+  { brandSlug: "dunn-edwards", colorSlug: "cottage-white-dew318" },
+  { brandSlug: "dunn-edwards", colorSlug: "foggy-day-de6226" },
+  { brandSlug: "dunn-edwards", colorSlug: "swiss-coffee-dew341" },
+  // Farrow & Ball
+  { brandSlug: "farrow-ball", colorSlug: "ammonite-274" },
+  { brandSlug: "farrow-ball", colorSlug: "cornforth-white-228" },
+  { brandSlug: "farrow-ball", colorSlug: "elephants-breath-229" },
+  { brandSlug: "farrow-ball", colorSlug: "hague-blue-30" },
+  { brandSlug: "farrow-ball", colorSlug: "stiffkey-blue-281" },
+  // PPG
+  { brandSlug: "ppg", colorSlug: "delicate-white-1001-1" },
+  { brandSlug: "ppg", colorSlug: "gypsum-1006-1" },
+  { brandSlug: "ppg", colorSlug: "olive-sprig-1125-4" },
+  { brandSlug: "ppg", colorSlug: "stonehenge-greige-1024-5" },
+  { brandSlug: "ppg", colorSlug: "swirling-smoke-1007-2" },
+  // Valspar
+  { brandSlug: "valspar", colorSlug: "gravity-4005-1b" },
+  { brandSlug: "valspar", colorSlug: "gray-silt-6002-1c" },
+  { brandSlug: "valspar", colorSlug: "notre-dame-5006-1b" },
+  { brandSlug: "valspar", colorSlug: "safari-beige-6006-2b" },
+  { brandSlug: "valspar", colorSlug: "warm-eucalyptus-8004-28f" },
+];
+
+// Major brands used as target brands when generating cross-brand match
+// URLs for the sitemap. Matches the same MAJOR_MATCH_BRANDS list used
+// elsewhere for brand-to-brand listing pages.
+export const MAJOR_MATCH_BRANDS = [
+  "sherwin-williams",
+  "benjamin-moore",
+  "behr",
+  "ppg",
+  "valspar",
+];


### PR DESCRIPTION
## Summary

The cluster audit flagged that individual cross-brand match pages (\`/match/[brand]/[colorSlug]-to-[brand]\`) were entirely absent from the sitemap. These answer "Behr equivalent of Agreeable Gray?" style queries that Google fields heavily, but Googlebot had to discover them via internal links from color detail pages — limiting crawl prioritization.

## Scoped MVP

Add a single new sitemap shard \`match-individual.xml\` covering the **47 popular source colors** used by \`generateStaticParams\` on the color detail page, each pointing at all 5 major target brands (excluding self):

  47 colors × 4-5 target brands = **~200 URLs**, one shard, well under the 50k limit

## Why this scope

The cluster audit's bigger ask — sitemap discoverability for **all** ~150k cross-brand match URLs across 14 brands — would require build-time enumeration and multiple sitemap shards. This MVP focuses crawl budget on the highest-value source-color × target-brand combinations (the same set Next.js pre-renders at build time) and unblocks the discoverability path immediately.

Non-popular colors' match pages still exist and are discoverable via the cross-brand matches section on each color detail page. They just don't get sitemap-level prioritization.

## Implementation

- **NEW** \`src/lib/popular-colors.ts\` — exports \`POPULAR_COLOR_SLUGS\` and \`MAJOR_MATCH_BRANDS\` so the color detail page (generateStaticParams) and sitemap (match-individual handler) share the same source of truth. Previously \`POPULAR_COLOR_SLUGS\` lived inline in the color page.
- \`src/app/api/sitemap/route.ts\` — adds \`"match-individual"\` to the index.
- \`src/app/api/sitemap/[id]/route.ts\` — gains a \`match-individual\` branch that cross-products the popular colors × major target brands, skipping self-pairs.

## Test plan

- [x] tsc clean
- [x] eslint clean (pre-existing img + ColorSwatch warnings unrelated)
- [ ] After deploy: \`curl https://www.paintcolorhq.com/sitemap/match-individual.xml | head -20\` returns ~200 URLs
- [ ] Spot-check a few match URLs (\`/match/sherwin-williams/agreeable-gray-7029-to-behr\`, etc.) return 200 not 404
- [ ] Re-submit sitemap in GSC and watch crawl pickup over the next week

## Stacked on top of

Conceptually unblocked by PR #31 (generateStaticParams populated \`POPULAR_COLOR_SLUGS\` inline in color page). This PR extracts that list to a shared module so the sitemap can reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)