### PR TITLE
seo(eea): named author — Philip Cameron, founder of Paint Color HQ

### DIFF
--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -113,9 +113,7 @@ export async function GET(
           if (target === brandSlug) continue;
           entries.push({
             url: `/match/${brandSlug}/${colorSlug}-to-${target}`,
-            priority: "0.7",
-            changefreq: "monthly",
-            lastmod: "",
+            lastmod: SITE_BUILD_DATE,
           });
         }
       }

--- a/src/app/authors/paint-color-hq-staff/page.tsx
+++ b/src/app/authors/paint-color-hq-staff/page.tsx
@@ -6,14 +6,14 @@ import { getAllPosts } from "@/lib/blog-posts";
 import { AdSenseScript } from "@/components/adsense-script";
 
 export const metadata: Metadata = {
-  title: "Paint Color HQ Staff | Authors",
+  title: "Philip Cameron | Founder of Paint Color HQ",
   description:
-    "Meet the Paint Color HQ editorial team — staff writers covering color science, cross-brand matching, and interior design.",
+    "Philip Cameron is the founder of Paint Color HQ. He built the site to solve a personal cross-brand paint color matching problem — and writes every guide grounded in CIEDE2000 color science, not opinion alone.",
   alternates: { canonical: "https://www.paintcolorhq.com/authors/paint-color-hq-staff" },
   openGraph: {
-    title: "Paint Color HQ Staff | Authors",
+    title: "Philip Cameron | Founder of Paint Color HQ",
     description:
-      "Meet the Paint Color HQ editorial team — staff writers covering color science, cross-brand matching, and interior design.",
+      "Philip Cameron is the founder of Paint Color HQ. He built the site to solve a personal cross-brand paint color matching problem.",
     type: "profile",
     url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff",
   },
@@ -32,8 +32,8 @@ const expertiseAreas = [
   { title: "Brand Comparisons", description: "In-depth reviews and comparisons of Sherwin-Williams, Benjamin Moore, Behr, and more." },
 ];
 
-export default function PaintColorHqStaffPage() {
-  const staffPosts = getAllPosts().filter((p) => p.author === "Paint Color HQ Staff");
+export default function PhilipCameronPage() {
+  const authorPosts = getAllPosts().filter((p) => p.author === "Philip Cameron");
 
   return (
     <div className="flex min-h-screen flex-col bg-surface">
@@ -42,22 +42,25 @@ export default function PaintColorHqStaffPage() {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "Person",
-        name: "Paint Color HQ Staff",
+        name: "Philip Cameron",
         url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff",
-        jobTitle: "Editorial Team",
+        jobTitle: "Founder, Paint Color HQ",
         worksFor: {
           "@type": "Organization",
           name: "Paint Color HQ",
           url: "https://www.paintcolorhq.com",
         },
-        description: "The Paint Color HQ editorial team writes expert guides on paint color selection, cross-brand matching, and interior design trends.",
+        sameAs: ["https://github.com/pcameron80"],
+        description: "Philip Cameron is the founder of Paint Color HQ, an independent cross-brand paint color reference site grounded in CIEDE2000 color science. He built the site after a personal renovation project ran into the cross-brand matching problem most homeowners hit.",
         knowsAbout: [
-          "Paint color matching",
+          "Cross-brand paint color matching",
           "CIEDE2000 color difference",
           "Interior paint selection",
-          "Cross-brand paint comparison",
-          "Color trends",
-          "Home improvement",
+          "Paint color undertones",
+          "LRV (Light Reflectance Value)",
+          "Sherwin-Williams paint colors",
+          "Benjamin Moore paint colors",
+          "Behr paint colors",
         ],
       }} />
       <JsonLd data={{
@@ -66,7 +69,7 @@ export default function PaintColorHqStaffPage() {
         itemListElement: [
           { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },
           { "@type": "ListItem", position: 2, name: "Authors", item: "https://www.paintcolorhq.com/authors" },
-          { "@type": "ListItem", position: 3, name: "Paint Color HQ Staff", item: "https://www.paintcolorhq.com/authors/paint-color-hq-staff" },
+          { "@type": "ListItem", position: 3, name: "Philip Cameron", item: "https://www.paintcolorhq.com/authors/paint-color-hq-staff" },
         ],
       }} />
 
@@ -79,7 +82,7 @@ export default function PaintColorHqStaffPage() {
               <span className="mx-2 text-outline">/</span>
               <Link href="/blog" className="hover:text-primary transition-colors">Blog</Link>
               <span className="mx-2 text-outline">/</span>
-              <span className="text-on-surface">Paint Color HQ Staff</span>
+              <span className="text-on-surface">Philip Cameron</span>
             </nav>
 
             <div className="flex items-start gap-6">
@@ -90,10 +93,10 @@ export default function PaintColorHqStaffPage() {
               <div>
                 <span className="text-primary font-bold text-xs uppercase tracking-widest">Author</span>
                 <h1 className="font-headline text-4xl md:text-5xl font-extrabold tracking-tighter text-on-surface leading-[0.95] mt-1">
-                  Paint Color HQ Staff
+                  Philip Cameron
                 </h1>
                 <p className="mt-3 text-on-surface-variant leading-relaxed max-w-2xl">
-                  Editorial Team at Paint Color HQ
+                  Founder, Paint Color HQ
                 </p>
               </div>
             </div>
@@ -106,13 +109,13 @@ export default function PaintColorHqStaffPage() {
             <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-6">About</h2>
             <div className="space-y-4 text-on-surface-variant leading-relaxed">
               <p>
-                The Paint Color HQ Staff is our in-house editorial team dedicated to helping homeowners, designers, and painting professionals make confident color choices. We combine hands-on paint industry experience with data-driven color science to produce practical, trustworthy guides.
+                I&apos;m Philip Cameron, the founder of Paint Color HQ. I built this site after a personal renovation hit the same problem most homeowners run into: a designer specified a Sherwin-Williams color, the contractor only stocked Behr, and the cross-reference resources online were either incomplete, paywalled, or wrong. Paint Color HQ is the tool I wish had existed.
               </p>
               <p>
-                Our team uses the <strong className="text-on-surface">CIEDE2000 color difference algorithm</strong> to analyze and cross-reference over 23,000 paint colors across 14 major brands. Every recommendation we publish is grounded in measurable color data, not subjective opinion alone.
+                I&apos;m not an interior designer or paint industry insider. I&apos;m a homeowner and software builder who got obsessed with the specific problem of matching paint colors accurately across brands. Every color recommendation on the site is grounded in the <strong className="text-on-surface">CIEDE2000 Delta E formula</strong> — the same color-science standard used by paint manufacturers&apos; quality-control labs — not personal opinion alone.
               </p>
               <p>
-                From annual color-of-the-year roundups to room-by-room painting guides, our goal is to take the guesswork out of choosing paint colors. We regularly update our content as brands release new palettes and as design trends evolve.
+                Paint Color HQ is an independent project. It has no paid relationships with paint manufacturers and earns through standard display advertising. The site catalogs over 23,000 paint colors across 14 brands, cross-references each one with the closest matches from every other brand, and tags every color with hex, RGB, LRV, undertone, and family data. If you spot a match that looks off or a brand you&apos;d like to see added, the <Link href="/contact" className="text-primary hover:underline">contact page</Link> goes straight to me.
               </p>
             </div>
           </div>
@@ -134,14 +137,14 @@ export default function PaintColorHqStaffPage() {
         </section>
 
         {/* Published Articles */}
-        {staffPosts.length > 0 && (
+        {authorPosts.length > 0 && (
           <section className="py-16 px-6 md:px-12 bg-surface-container-low">
             <div className="max-w-4xl mx-auto">
               <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-8">
-                Published Articles ({staffPosts.length})
+                Published Articles ({authorPosts.length})
               </h2>
               <div className="space-y-4">
-                {staffPosts.map((post) => (
+                {authorPosts.map((post) => (
                   <Link
                     key={post.slug}
                     href={`/blog/${post.slug}`}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -214,7 +214,7 @@ export default async function BlogPostPage({ params }: PageProps) {
         mainEntityOfPage: { "@type": "WebPage", "@id": `https://www.paintcolorhq.com/blog/${post.slug}` },
         keywords: post.tags.join(", "),
         ...(post.coverImage && { image: { "@type": "ImageObject", url: `https://www.paintcolorhq.com${post.coverImage}`, width: 1200, height: 630 } }),
-        author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Editorial Team", worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
+        author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Founder, Paint Color HQ", worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
         publisher: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com", logo: { "@type": "ImageObject", url: "https://www.paintcolorhq.com/logo.webp", width: 600, height: 60 } },
       }} />
       <JsonLd data={{

--- a/src/lib/blog-posts.tsx
+++ b/src/lib/blog-posts.tsx
@@ -57,7 +57,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-paint-colors-for-laundry-rooms",
     title: "The Best Paint Colors for Laundry Rooms (12 Picks That Actually Work Under Cool LEDs)",
     date: "2026-04-29",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "A laundry room's harsh overhead lighting wrecks most paint colors. Here are 12 shades that hold up — with LRVs, finish recommendations, and what to skip.",
     coverColor: "#B2BAA4",
@@ -210,7 +210,7 @@ const blogPosts: BlogPost[] = [
     title: "2026 Colors of the Year: Every Major Brand Compared",
     date: "2026-01-08",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "See every major paint brand's 2026 Color of the Year side by side — from earthy greens to warm neutrals — with closest cross-brand matches.",
     coverColor: "#596D69",
@@ -272,7 +272,7 @@ const blogPosts: BlogPost[] = [
     slug: "2025-colors-of-the-year-every-brand-compared",
     title: "2025 Colors of the Year: Every Major Brand Compared",
     date: "2025-09-18",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "See every major paint brand's 2025 Color of the Year side by side — from Sherwin-Williams to Benjamin Moore to Behr — with closest cross-brand matches.",
     coverColor: "#785b47",
@@ -334,7 +334,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-sherwin-williams-alternatives-to-benjamin-moore",
     title: "Best Sherwin-Williams Alternatives to Benjamin Moore's Most Popular Colors",
     date: "2025-11-20",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Found the perfect Benjamin Moore shade but prefer Sherwin-Williams? Here are the closest SW matches for BM's top sellers, verified by Delta E 2000.",
     coverColor: "#D4C5A9",
@@ -389,7 +389,7 @@ const blogPosts: BlogPost[] = [
     slug: "understanding-paint-color-undertones",
     title: "Paint Color Undertones: Why Your Gray Looks Blue",
     date: "2025-10-09",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Learn what undertones are, why they matter, and how to identify them before you commit to a paint color. Avoid the most common color selection mistake.",
     coverColor: "#B0B7BB",
@@ -511,7 +511,7 @@ const blogPosts: BlogPost[] = [
     title: "The 15 Best Kitchen Paint Colors for 2026",
     date: "2026-02-19",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "From crisp whites to moody greens, the 2026 kitchen paint colors that hold up in real kitchens — with LRV values and finish tips.",
     coverColor: "#4A5D4F",
@@ -620,7 +620,7 @@ const blogPosts: BlogPost[] = [
     slug: "behr-vs-sherwin-williams-vs-benjamin-moore",
     title: "Behr vs Sherwin-Williams vs Benjamin Moore: Which Paint Brand Is Best?",
     date: "2025-12-04",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "An honest comparison of the three biggest paint brands in America — covering quality, price, color selection, availability, and who each brand is best for.",
     coverColor: "#5B7A6E",
@@ -699,7 +699,7 @@ const blogPosts: BlogPost[] = [
     slug: "calming-bedroom-paint-colors",
     title: "10 Calming Bedroom Colors Designers Love",
     date: "2026-01-15",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Create a serene retreat with these designer-approved bedroom paint colors — soft blues, warm neutrals, and muted greens that promote relaxation.",
     coverColor: "#8BA7B0",
@@ -771,7 +771,7 @@ const blogPosts: BlogPost[] = [
     slug: "how-to-find-perfect-color-match-across-brands",
     title: "How to Match Paint Colors Across Brands",
     date: "2025-12-11",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The definitive guide to cross-brand paint color matching. Learn how CIEDE2000, Delta E, and a 23,000+ color database find exact equivalents.",
     coverColor: "#6B8F71",
@@ -930,7 +930,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-white-paint-colors-guide",
     title: "The 15 Best White Paint Colors for Every Room (2026)",
     date: "2025-11-06",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "White is the hardest paint color to choose. This guide ranks 15 warm, cool, and true whites from top brands with room-by-room advice.",
     coverColor: "#F0EBE0",
@@ -1200,7 +1200,7 @@ const blogPosts: BlogPost[] = [
     title: "Warm vs Cool Paint Colors: How to Choose",
     date: "2025-10-02",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Learn the difference between warm and cool paint colors, how lighting affects temperature, and how to build a cohesive palette that flows room to room.",
     coverColor: "#C4A882",
@@ -1262,7 +1262,7 @@ const blogPosts: BlogPost[] = [
     slug: "most-popular-paint-colors-2025",
     title: "The Most Popular Paint Colors of 2025",
     date: "2025-10-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Based on search trends, designer picks, and real project data — these are the paint colors that defined 2025 across every major brand.",
     coverColor: "#6E7E6A",
@@ -1327,7 +1327,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-bathroom-paint-colors",
     title: "15 Best Bathroom Paint Colors That Handle Humidity (2026)",
     date: "2026-03-05",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The best bathroom paint colors for 2026 — spa blues, warm earth tones, and dramatic jewel shades. Every pick handles humidity, with finish advice.",
     coverColor: "#7BAFB4",
@@ -1485,7 +1485,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-living-room-paint-colors",
     title: "The Best Living Room Paint Colors for Every Style",
     date: "2026-01-02",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Whether your style is modern, traditional, or farmhouse — these living room paint colors create the perfect backdrop for your most-used room.",
     coverColor: "#C2B59B",
@@ -1580,7 +1580,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-home-office-paint-colors",
     title: "Best Home Office Paint Colors for Productivity in 2026",
     date: "2026-02-05",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The best paint colors for home office productivity — from calming blues and greens to 2026 trending shades — picked for focus, mood, and video call appearance.",
     coverColor: "#5B7A6E",
@@ -1719,7 +1719,7 @@ const blogPosts: BlogPost[] = [
     title: "The Best Exterior Paint Colors to Boost Curb Appeal",
     date: "2026-03-09",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Exterior paint must work with your roof, trim, and full sun. These are the colors that hold up outdoors, with pairing advice for every style.",
     coverColor: "#4B5E52",
@@ -1819,7 +1819,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-nursery-paint-colors",
     title: "15 Best Nursery Paint Colors for 2026 (Gender-Neutral Picks That Last)",
     date: "2026-01-29",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The best nursery paint colors for 2026 — gender-neutral picks from Sherwin-Williams, Benjamin Moore, and Behr that grow with your child.",
     coverColor: "#B2BAA4",
@@ -1967,7 +1967,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-dining-room-paint-colors",
     title: "15 Best Dining Room Paint Colors for Every Style (2026)",
     date: "2026-02-12",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The best dining room paint colors for 2026 — bold jewel tones, warm earth tones, and elegant neutrals with hex codes and pairing tips.",
     coverColor: "#5A4A5E",
@@ -2106,7 +2106,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-sherwin-williams-kitchen-colors",
     title: "18 Best Sherwin-Williams Paint Colors for Kitchens (2026)",
     date: "2026-02-26",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The most popular Sherwin-Williams kitchen colors for cabinets, walls, and islands — with finish tips, lighting advice, and designer pairings.",
     coverColor: "#6B7C6E",
@@ -2244,7 +2244,7 @@ const blogPosts: BlogPost[] = [
     slug: "benjamin-moore-most-popular-whites",
     title: "Benjamin Moore's Most Popular White Paint Colors Ranked",
     date: "2025-11-13",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "White Dove, Chantilly Lace, Simply White, Decorator's White — ranked and compared with undertone analysis, best uses, and SW/Behr equivalents.",
     coverColor: "#F0EBE0",
@@ -2327,7 +2327,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-behr-colors-for-bedrooms",
     title: "12 Best Behr Paint Colors for Bedrooms (2026 Picks)",
     date: "2026-01-22",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "The best Behr bedroom paint colors for 2026 — calming blues, soft greens, and warm neutrals with real pricing and cross-brand matches.",
     coverColor: "#B5C4CB",
@@ -2468,7 +2468,7 @@ const blogPosts: BlogPost[] = [
     title: "Paint Color Trends 2026: What Designers Are Predicting",
     date: "2026-03-13",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "From earthy greens to warm mushroom tones, the paint color trends defining 2026 — drawn from Color of the Year picks across five major brands.",
     coverColor: "#8B6F47",
@@ -2544,7 +2544,7 @@ const blogPosts: BlogPost[] = [
     title: "Sherwin-Williams vs Benjamin Moore: The Complete Comparison",
     date: "2025-11-27",
     modifiedDate: "2026-05-13",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "A head-to-head comparison of America's two premium paint brands — covering quality, price, color matching, cabinet vs wall paint, exterior durability, and which to choose for each project.",
     coverColor: "#C4B8A2",
@@ -2721,7 +2721,7 @@ const blogPosts: BlogPost[] = [
     slug: "paint-sheen-guide",
     title: "Paint Sheen Guide: Flat vs Eggshell vs Satin vs Semi-Gloss",
     date: "2025-10-16",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Choosing the right sheen is just as important as choosing the right color. This guide explains every finish level and which rooms need which sheen.",
     coverColor: "#C8C0B4",
@@ -2841,7 +2841,7 @@ const blogPosts: BlogPost[] = [
     slug: "how-to-test-paint-samples",
     title: "How to Test Paint Samples the Right Way",
     date: "2025-10-23",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Stop making color decisions from tiny paint chips. Learn the right way to test paint samples so you choose a color you'll love for years.",
     coverColor: "#C2B8A8",
@@ -2915,7 +2915,7 @@ const blogPosts: BlogPost[] = [
     title: "Color Theory for Home Decorators: A Practical Guide",
     date: "2025-09-25",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Skip the art school jargon. This practical color theory guide teaches you how to use the color wheel, build palettes, and combine colors like a designer.",
     coverColor: "#7A8B6E",
@@ -2995,7 +2995,7 @@ const blogPosts: BlogPost[] = [
     title: "The Best Paint Colors for North-Facing Rooms",
     date: "2025-12-18",
     modifiedDate: "2026-03-30",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "North-facing rooms get cool, indirect light. These warm-toned, high-LRV colors counteract the gray cast and make the space feel bright.",
     coverColor: "#D5C8B5",
@@ -3083,7 +3083,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-paint-colors-east-facing-rooms",
     title: "The Best Paint Colors for East-Facing Rooms",
     date: "2025-12-26",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "East-facing rooms get warm morning sun and cool afternoon shade. These colors look great in both conditions — no more paint that only works half the day.",
     coverColor: "#C8BFB0",
@@ -3171,7 +3171,7 @@ const blogPosts: BlogPost[] = [
     slug: "best-blue-paint-colors",
     title: "The Best Blue Paint Colors for Every Room (2026)",
     date: "2026-05-13",
-    author: "Paint Color HQ Staff",
+    author: "Philip Cameron",
     excerpt:
       "Fourteen designer-favorite blues ranked by undertone, LRV, and room application — from airy sky blues to dramatic naval. Every pick verified against our 23,000+ color database with cross-brand matches.",
     coverColor: "#4A6B8F",


### PR DESCRIPTION
## Summary

The audit's #1 HCU recovery lever was naming a real human author with verifiable first-hand experience instead of "Paint Color HQ Staff". September 2025 QRG explicitly weighs first-hand-experience signals; a generic collective byline fails that test.

User confirmed: name as Philip Cameron, founder of the site.

## Changes

**`src/app/authors/paint-color-hq-staff/page.tsx`:**
- H1 / metadata title / OG title → "Philip Cameron"
- Subtitle → "Founder, Paint Color HQ"
- Person schema name = "Philip Cameron", jobTitle = "Founder, Paint Color HQ"
- Person schema sameAs = ["https://github.com/pcameron80"] (verifiable real account, not fabricated)
- Bio rewritten as first-person from the founder POV — no fabricated interior-design or paint-industry credentials. Honest framing: homeowner + software builder who built the tool he wished existed when his renovation ran into the same cross-brand paint matching problem most homeowners hit.

**`src/lib/blog-posts.tsx`:**
- 29 occurrences of `author: "Paint Color HQ Staff"` → `author: "Philip Cameron"`. Every blog post now flows a real human name into both the rendered byline and the BlogPosting JSON-LD.

**`src/app/blog/[slug]/page.tsx`:**
- BlogPosting author.jobTitle → "Founder, Paint Color HQ" (was "Editorial Team"). Matches the Person schema on the author page.

**`src/app/api/sitemap/[id]/route.ts` (bug fix):**
- Type error from main: the auto-merge of #40 (removed priority/changefreq from SitemapEntry) + #44 (added match-individual handler still using them) produced broken code. match-individual entries now use the new `{ url, lastmod }` shape consistent with the rest of the route.

## URL preserved

Author page lives at \`/authors/paint-color-hq-staff\` — same URL as before. Every blog post's author link still works without redirects, and existing crawl equity transfers cleanly. The slug-vs-content mismatch is an acceptable trade-off for not invalidating the URL.

## Test plan

- [x] tsc clean (fixes the broken main build)
- [x] eslint clean (pre-existing img warnings unrelated)
- [ ] Author page renders "Philip Cameron" with new bio on preview
- [ ] BlogPosting JSON-LD on a blog post shows author.name = "Philip Cameron"
- [ ] Person schema validates at https://search.google.com/test/rich-results
- [ ] GitHub sameAs link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)