### PR TITLE
seo(index): noindex weak match pages + tighten family taxonomy regex

### DIFF
--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -49,10 +49,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   // ("What is the Behr equivalent of Agreeable Gray?") to lift CTR and
   // align with the way Google surfaces "[Brand] equivalent of [color]" results.
   const shortTitle = `${targetBrand.name} Equivalent of ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant}`;
+  // Index only matches close enough to be useful answers. At Delta E >= 3 the
+  // "match" carries a visible difference and the page reads as a low-quality
+  // doorway at scale (~150k crawlable pairs total).
+  const deltaScore = best ? Number(best.delta_e_score) : null;
+  const shouldIndex = deltaScore !== null && deltaScore < 3;
   return {
     title: { absolute: shortTitle },
     description: `Find the closest ${targetBrand.name} match for ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant} (${sourceColor.hex.toUpperCase()}). ${note}. Compare hex, LRV, and undertone side by side.`,
     alternates: { canonical: url },
+    robots: shouldIndex ? undefined : { index: false, follow: true },
     openGraph: { title: shortTitle, description: `Find the closest ${targetBrand.name} equivalent.`, url,
       images: [{ url: `/api/og?hex=${encodeURIComponent(sourceColor.hex)}&name=${encodeURIComponent(sourceColor.name)}&brand=${encodeURIComponent(`${sourceColor.brand.name} \u2192 ${targetBrand.name}`)}`, width: 1200, height: 630 }],
     },

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -245,18 +245,17 @@ export async function searchColors(
 }
 
 // Match colors where the LAB-based classifier assigned this family OR the
-// color name contains the family slug as a substring. Catches name-driven
-// blues like "Sleepy Blue" or "Cornflower Blue" that the classifier puts
-// into adjacent families (neutral, gray) based on hex values. Soft
-// multi-family — a single color can appear on both /family/blue and
-// /family/neutral if its name says blue but its hex sits near the boundary.
+// color name contains the family slug as a standalone word. Catches
+// name-driven blues like "Sleepy Blue" or "Cornflower Blue" that the
+// classifier puts into adjacent families (neutral, gray) based on hex values.
 //
-// `name.ilike.%${familySlug}%` matches substrings case-insensitively. For
-// paint color names this is safe — false positives like "Babyblue" matching
-// "blue" are actually wanted (it IS a blue). For slugs like `off-white`
-// the substring rarely appears in names so the OR is effectively a no-op.
+// The name match uses POSIX word-boundary regex (\m, \M) rather than a raw
+// substring. Substring matching was producing false positives at scale:
+// `name ILIKE '%red%'` was pulling "Tired Rose" and "Spread the Word" into
+// /family/red; `%tan%` was matching "Tangerine". Word boundaries fix this
+// while still catching multi-word names like "Light Tan" or "Powder Blue".
 function familyMatchFilter(familySlug: string): string {
-  return `color_family.eq.${familySlug},name.ilike.%${familySlug}%`;
+  return `color_family.eq.${familySlug},name.imatch.\\m${familySlug}\\M`;
 }
 
 export async function getColorsByFamily(


### PR DESCRIPTION
## Summary

Two index-discipline changes from the 2026-05-12 programmatic SEO audit:

- **H4 — Noindex Delta E ≥ 3 match pages.** ~150k cross-brand match URLs are crawlable; only ~200 are in the sitemap. The remaining bulk consists of low-similarity pairs that read as low-quality doorway pages at scale. Match pages whose best Delta E ≥ 3 ("Visible difference") now emit `robots: noindex, follow` via `generateMetadata`. Internal navigation still works.
- **H3 — Tighten family taxonomy regex.** `getColorsByFamily` was using `name ILIKE '%red%'` which pulled "Tired Rose" and "Spread the Word" into `/family/red`, and `%tan%` was matching "Tangerine". Switched to POSIX word-boundary regex (`~*` with `\m`/`\M`) so name-driven matches still work for "Sleepy Blue", "Light Tan", etc. but no longer leak through internal substrings.

Both changes are reversible.

## Test plan

- [ ] Preview deploy renders successfully
- [ ] `/colors/family/red` no longer includes "Tired Rose" / "Spread the Word"
- [ ] `/colors/family/tan` no longer includes "Tangerine"
- [ ] `/colors/family/blue` still includes "Sleepy Blue" / "Cornflower Blue"
- [ ] Visit `/match/sherwin-williams/agreeable-gray-7029-to-behr` — should be indexable (Delta E < 3 for canonical pairs)
- [ ] Visit a random low-Delta-E match URL — should have `noindex` meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)