### PR TITLE
seo(index): noindex code-only color names + thin-content gate

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -109,6 +109,32 @@ function extractVariantSuffix(slug: string, colorNumber: string | null | undefin
   return ` (variant ${digit})`;
 }
 
+// Thin-content gate. Two paths to noindex:
+//   1. Code-only name: when the color name has no alphabetic run of 3+
+//      letters (e.g. Behr "YL-W15", "PPU5-16"). These can't rank for
+//      natural-language queries — no one searches "YL-W15 paint." Colors
+//      with real-word names like "Red", "Tan", or "Imagine .04" still
+//      pass even when name overlaps with color_number.
+//   2. Data quality score < 2: missing two or more of {LRV, undertone,
+//      family, has-name}. Today every color has score >= 3 so this is
+//      future-proofing for sparse imports.
+function isCodeOnlyName(name: string): boolean {
+  if (!name.trim()) return true;
+  // Unicode-aware so "Crème" reads as a 5-letter word, not "Cr" + "me".
+  const runs = name.match(/\p{L}+/gu);
+  if (!runs) return true;
+  return runs.every((r) => r.length < 3);
+}
+
+function dataQualityScore(color: { lrv: number | string | null; undertone: string | null; color_family: string | null; name: string }): number {
+  let score = 0;
+  if (color.lrv !== null && color.lrv !== undefined) score++;
+  if (color.undertone) score++;
+  if (color.color_family) score++;
+  if (!isCodeOnlyName(color.name)) score++;
+  return score;
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { brandSlug, colorSlug } = await params;
   const color = await getColorBySlug(brandSlug, colorSlug);
@@ -138,10 +164,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const titleSuffix = familyForTitle
     ? ` | ${lrvForTitle != null ? `LRV ${lrvForTitle} ` : ""}${familyForTitle} Paint Color`
     : ` | ${color.hex.toUpperCase()}`; // fall back to hex if family unavailable
+  const shouldIndex = !isCodeOnlyName(color.name) && dataQualityScore(color) >= 2;
   return {
     title: `${color.name}${colorNum} by ${color.brand.name}${variant}${titleSuffix}`,
     description: generateMetaDescription(color) + variant,
     alternates: { canonical: url },
+    robots: shouldIndex ? undefined : { index: false, follow: true },
     openGraph: {
       title: `${color.name}${colorNum} by ${color.brand.name}${variant}`,
       description: `${color.name} (${color.hex.toUpperCase()}) by ${color.brand.name}${variant}. Find closest matches from other brands.`,


### PR DESCRIPTION
## Summary

C2 from the 2026-05-12 programmatic SEO audit. Two-path noindex gate on `/colors/[brand]/[slug]`:

1. **Code-only name detection.** If every alphabetic run in `color.name` is < 3 letters, the name is treated as a code (Behr "YL-W15", etc.). Real words preserved, including Unicode like "Crème" (uses `\p{L}` letter class).
2. **Data quality score < 2.** Counts presence of LRV, undertone, family, and non-code name. Future-proofing for sparse imports — today every row has score ≥ 3.

## Impact today

**11 of 23,438 color pages noindex'd (0.05%).** Breakdown:
- 6 Behr `YL-W*` codes
- 2 Vista Paint ("D√©j√† vu" mojibake, "P.J.'s")
- 2 Benjamin Moore ("Mt.")
- 1 Valspar ("Oh So Vo")

None of these earn traffic. They're pure index hygiene wins — and the gate auto-tightens if a future brand import lands with sparse metadata.

## Notes

- The mojibake `vista-paint/d-j-vu-c-468` (should be "Déjà vu") is a separate data bug worth tracking.
- Duplicate `mt-ac-39` and `yl-w*` rows showing up in sampling suggest the DB has some duplicate entries — also worth a follow-up.

## Test plan

- [ ] Preview deploy succeeds
- [ ] `/colors/behr/yl-w15-yl-w15` returns `<meta name="robots" content="noindex, follow">`
- [ ] `/colors/sherwin-williams/creme-7556` does NOT have noindex (the Crème false-positive case)
- [ ] `/colors/sherwin-williams/agreeable-gray-7029` does NOT have noindex (canonical case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)