### PR TITLE
seo(index): noindex variant slugs on color + match pages (H1)

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -109,6 +109,14 @@ function extractVariantSuffix(slug: string, colorNumber: string | null | undefin
   return ` (variant ${digit})`;
 }
 
+// A slug like `agreeable-gray-7029-2` is a variant of `agreeable-gray-7029`.
+// 49 such pages exist across Behr, Kilz, and Benjamin Moore — many cannibalize
+// the primary slug because their generated copy differs only by "(variant 2)"
+// in the title. Treat them as noindex so the primary keeps the ranking.
+export function isVariantSlug(slug: string, colorNumber: string | null | undefined): boolean {
+  return extractVariantSuffix(slug, colorNumber) !== "";
+}
+
 // Thin-content gate. Two paths to noindex:
 //   1. Code-only name: when the color name has no alphabetic run of 3+
 //      letters (e.g. Behr "YL-W15", "PPU5-16"). These can't rank for
@@ -164,7 +172,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const titleSuffix = familyForTitle
     ? ` | ${lrvForTitle != null ? `LRV ${lrvForTitle} ` : ""}${familyForTitle} Paint Color`
     : ` | ${color.hex.toUpperCase()}`; // fall back to hex if family unavailable
-  const shouldIndex = !isCodeOnlyName(color.name) && dataQualityScore(color) >= 2;
+  const shouldIndex = !isCodeOnlyName(color.name) && dataQualityScore(color) >= 2 && !isVariantSlug(colorSlug, color.color_number);
   return {
     title: `${color.name}${colorNum} by ${color.brand.name}${variant}${titleSuffix}`,
     description: generateMetaDescription(color) + variant,

--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -51,9 +51,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const shortTitle = `${targetBrand.name} Equivalent of ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant}`;
   // Index only matches close enough to be useful answers. At Delta E >= 3 the
   // "match" carries a visible difference and the page reads as a low-quality
-  // doorway at scale (~150k crawlable pairs total).
+  // doorway at scale (~150k crawlable pairs total). Also noindex when the
+  // source slug is a variant (e.g. agreeable-gray-7029-2-to-behr) — the base
+  // match page already covers the query.
   const deltaScore = best ? Number(best.delta_e_score) : null;
-  const shouldIndex = deltaScore !== null && deltaScore < 3;
+  const isVariantSource = variant !== "";
+  const shouldIndex = deltaScore !== null && deltaScore < 3 && !isVariantSource;
   return {
     title: { absolute: shortTitle },
     description: `Find the closest ${targetBrand.name} match for ${sourceColor.brand.name} ${sourceColor.name}${colorNum}${variant} (${sourceColor.hex.toUpperCase()}). ${note}. Compare hex, LRV, and undertone side by side.`,


### PR DESCRIPTION
## Summary

H1 from the 2026-05-12 programmatic SEO audit. Variant slugs like \`agreeable-gray-7029-2\` cannibalize the primary \`agreeable-gray-7029\` — same data, same metadata except for "(variant 2)" injected into the title.

**Affected slugs in DB:** 49 total
- 35 Behr
- 10 Kilz
- 4 Benjamin Moore

28 have a base slug that also exists in the DB; 21 are orphans. Both groups get noindex regardless.

## What ships

- New \`isVariantSlug(slug, colorNumber)\` helper in the color page.
- Color page \`shouldIndex\` now requires \`!isVariantSlug(...)\` on top of the existing thin-content gate.
- Match page \`shouldIndex\` adds the same check — \`/match/sw/agreeable-gray-7029-2-to-behr\` noindex'd even when Delta E is low.

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/colors/behr/sterling-780e-3-2\` returns \`noindex, follow\` (true variant, base \`sterling-780e-3\` exists)
- [ ] \`/colors/benjamin-moore/metropolitan-af-690-2\` returns \`noindex, follow\` (true variant, base exists)
- [ ] \`/colors/sherwin-williams/agreeable-gray-7029\` remains indexable (base, not a variant)
- [ ] \`/match/behr/sterling-780e-3-2-to-sherwin-williams\` returns \`noindex, follow\` even if Delta E is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)