### PR TITLE
seo(crawl): nofollow brand pagination beyond page 2 (M4)

### DIFF
--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -310,10 +310,18 @@ export default async function BrandPage({ params, searchParams }: PageProps) {
             if (currentPage < totalPages - 2) pages.push("ellipsis");
             addPage(totalPages);
 
+            // Pagination beyond page 2 gets rel="nofollow". Brand pages 2+ are
+            // noindex; pages 3+ are deep noindex pages that burn crawl budget
+            // every recrawl cycle. Sitemap covers color discovery for these
+            // deeper pages. Page 2 stays followed so its 60 colors (positions
+            // 61-120) still receive link signal from the brand.
+            const nofollowProps = (target: number) =>
+              target >= 3 ? { rel: "nofollow" as const } : {};
+
             return (
               <nav className="mt-12 flex items-center justify-center gap-2">
                 {currentPage > 1 && (
-                  <Link href={pageUrl(currentPage - 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">
+                  <Link href={pageUrl(currentPage - 1)} {...nofollowProps(currentPage - 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">
                     Previous
                   </Link>
                 )}
@@ -321,13 +329,13 @@ export default async function BrandPage({ params, searchParams }: PageProps) {
                   page === "ellipsis" ? (
                     <span key={`e${i}`} className="px-2 text-outline">...</span>
                   ) : (
-                    <Link key={page} href={pageUrl(page)}
+                    <Link key={page} href={pageUrl(page)} {...nofollowProps(page)}
                       className={`rounded-xl px-4 py-2.5 text-sm font-headline font-bold transition-all ${page === currentPage ? "bg-primary text-on-primary" : "bg-surface-container-lowest text-on-surface-variant border border-outline-variant/15 hover:text-primary"}`}
                     >{page}</Link>
                   )
                 )}
                 {currentPage < totalPages && (
-                  <Link href={pageUrl(currentPage + 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">
+                  <Link href={pageUrl(currentPage + 1)} {...nofollowProps(currentPage + 1)} className="rounded-xl bg-surface-container-lowest px-5 py-2.5 text-sm font-headline font-bold text-on-surface-variant border border-outline-variant/15 hover:text-primary transition-colors">
                     Next
                   </Link>
                 )}


### PR DESCRIPTION
## Summary

M4 from the 2026-05-12 programmatic SEO audit. Brand pages 2+ are noindex, but Google still crawls them every cycle. A brand with 50 paginated pages burns 49 wasted crawls per recrawl.

**Fix:** \`rel="nofollow"\` on pagination links targeting page ≥ 3. Page 2 stays followed so its 60 colors (positions 61–120) keep their brand-page link signal. Deep pagination stops burning crawl budget; colors are still discoverable via sitemap.

## Test plan

- [ ] Preview deploy succeeds
- [ ] On \`/brands/sherwin-williams\` (page 1), pagination link to page 2 has no \`rel="nofollow"\`
- [ ] On \`/brands/sherwin-williams\` (page 1), pagination links to pages 3+ all have \`rel="nofollow"\`
- [ ] On \`/brands/sherwin-williams?page=2\`, "Previous" link (to page 1) has no \`rel="nofollow"\`; "Next" link (to page 3) has \`rel="nofollow"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)