### PR TITLE
seo(linkgraph): cross-brand More from family carousel on color pages (H2)

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -11,7 +11,7 @@ import { SaveToProject } from "@/components/save-to-project";
 import { ShareButton } from "@/components/share-button";
 import { PinterestSaveButton } from "@/components/pinterest-save-button";
 import { redirect } from "next/navigation";
-import { getColorBySlug, getColorSlugByNumber, getCrossBrandMatches, findClosestColor, getSimilarColorsFromSameBrand } from "@/lib/queries";
+import { getColorBySlug, getColorSlugByNumber, getCrossBrandMatches, findClosestColor, getSimilarColorsFromSameBrand, getMoreFromFamily } from "@/lib/queries";
 import { generateColorDescription, generateMetaDescription } from "@/lib/color-description";
 import { getUndertoneDotClass } from "@/lib/undertone-utils";
 import { getRetailerLinks } from "@/lib/retailer-links";
@@ -211,7 +211,11 @@ export default async function ColorPage({ params }: PageProps) {
     notFound();
   }
 
-  const [matches, similarColors] = await Promise.all([getCrossBrandMatches(color.id), getSimilarColorsFromSameBrand(color)]);
+  const [matches, similarColors, moreFromFamily] = await Promise.all([
+    getCrossBrandMatches(color.id),
+    getSimilarColorsFromSameBrand(color),
+    getMoreFromFamily({ id: color.id, color_family: color.color_family, brand_id: color.brand_id }),
+  ]);
   const description = generateColorDescription(color, matches);
   const retailerLinks = getRetailerLinks(color.brand.slug, color.brand.name, color.name, color.color_number ?? undefined, color.color_family ?? undefined);
   const harmonies = await resolveHarmonies(color.hex);
@@ -427,6 +431,18 @@ export default async function ColorPage({ params }: PageProps) {
           <p className="mt-2 text-sm text-on-surface-variant">Other {color.brand.name} colors close to {color.name}.</p>
           <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
             {similarColors.map((s) => <ColorCard key={s.id} name={s.name} hex={s.hex} brandName={color.brand.name} brandSlug={brandSlug} colorSlug={s.slug} colorNumber={s.color_number} />)}
+          </div>
+        </section>
+      )}
+
+      {/* More from family — cross-brand colors in the same family. Spreads
+          internal link equity into the long tail (H2 from the SEO audit). */}
+      {moreFromFamily.length > 0 && color.color_family && (
+        <section className="max-w-7xl mx-auto px-6 md:px-12 py-16">
+          <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight">More {color.color_family} colors from other brands</h2>
+          <p className="mt-2 text-sm text-on-surface-variant">Cross-brand colors in the {color.color_family} family — useful when you want a similar look from a different brand.</p>
+          <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+            {moreFromFamily.map((c) => <ColorCard key={c.id} name={c.name} hex={c.hex} brandName={c.brand.name} brandSlug={c.brand.slug} colorSlug={c.slug} colorNumber={c.color_number} />)}
           </div>
         </section>
       )}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -469,6 +469,44 @@ export async function getSimilarColorsFromSameBrand(
     .slice(0, limit) as unknown as Color[];
 }
 
+// Returns colors from the same color_family but a different brand, with a
+// deterministic offset based on the source color id so every long-tail
+// color page surfaces a different 6-color subset. This is the cross-color
+// link distribution fix from the H2 internal-link audit: long-tail colors
+// only get 3-6 incoming links today (RGB neighbors via similar-from-same-
+// brand); this carousel adds ~6 cross-brand HTML anchors per page, pulling
+// equity from the popular pre-rendered 47 into the rest of the 23k corpus.
+export async function getMoreFromFamily(
+  color: { id: string; color_family: string | null; brand_id: string },
+  limit = 6,
+  poolSize = 60
+): Promise<ColorWithBrand[]> {
+  if (!color.color_family) return [];
+
+  const { data, error } = await supabase
+    .from("colors")
+    .select(COLOR_CARD_FIELDS_WITH_BRAND)
+    .eq("color_family", color.color_family)
+    .neq("brand_id", color.brand_id)
+    .neq("id", color.id)
+    .order("id")
+    .limit(poolSize);
+
+  if (error) throw error;
+  const pool = (data ?? []) as unknown as ColorWithBrand[];
+  if (pool.length <= limit) return pool;
+
+  // Hash the source id to a stable offset. Same source color always returns
+  // the same 6 candidates, but adjacent source colors return overlapping-but-
+  // different subsets — spreads incoming links across the family pool.
+  let hash = 0;
+  for (let i = 0; i < color.id.length; i++) {
+    hash = ((hash << 5) - hash + color.id.charCodeAt(i)) | 0;
+  }
+  const start = Math.abs(hash) % Math.max(1, pool.length - limit);
+  return pool.slice(start, start + limit);
+}
+
 export async function getTopCrossBrandMatches(
   sourceBrandSlug: string,
   targetBrandSlug: string,


### PR DESCRIPTION
## Summary

H2 from the 2026-05-12 programmatic SEO audit — the biggest remaining lever in the audit's "long-tail orphaning" finding.

**Problem:** Long-tail color pages get ~3–6 incoming internal links (RGB neighbors via \`getSimilarColorsFromSameBrand\`, plus 1–2 cross-brand match links). The popular 47 pre-rendered slugs get compound link-equity advantages. That's a 20–50× gap.

**Fix:** Every color page now surfaces 6 same-family / different-brand colors in a deterministic carousel. The 6 are selected via hash of the source color's id, so adjacent pages show overlapping-but-different subsets — link distribution rotates evenly across the corpus.

**Impact:** 23,438 pages × 6 new HTML anchors = ~140k new cross-color edges in the internal link graph. Real PageRank flows (unlike the existing \`isSimilarTo\` JSON-LD which is metadata-only).

## What ships

- \`getMoreFromFamily(color, limit, poolSize)\` in \`src/lib/queries.ts\`. Pool of 60 candidates, deterministic slice of 6.
- New section between "Similar [brand] Colors" and the FAQ on color pages.

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/colors/sherwin-williams/agreeable-gray-7029\` shows a "More gray colors from other brands" section with 6 non-SW cards
- [ ] \`/colors/benjamin-moore/hale-navy-hc-154\` shows 6 non-BM cards (note: family is "gray" per classifier, so it'll show grays)
- [ ] \`/colors/behr/pink-hydrangea-160a-3\` shows 6 non-Behr pink cards
- [ ] All cards are real \`<a>\` links to the target color pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)