### PR TITLE
seo(sitemap): per-row lastmod from created_at (M3)

### DIFF
--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAllColorSlugs, getAllBrands, getAllColorFamilies } from "@/lib/queries";
+import { getAllColorSlugs, getAllBrands, getAllColorFamilies, getLatestColorDateByBrand, getLatestColorDateByFamily } from "@/lib/queries";
 import { getAllBlogSlugs, getPostBySlug } from "@/lib/blog-posts";
 import { inspirationPalettes } from "@/lib/palettes";
 import { POPULAR_COLOR_SLUGS, MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
@@ -66,10 +66,12 @@ export async function GET(
         { url: "/authors/paint-color-hq-staff", lastmod: SITE_BUILD_DATE },
       ];
     } else if (id === "brands") {
-      const brands = await getAllBrands();
+      const [brands, latestByBrand] = await Promise.all([getAllBrands(), getLatestColorDateByBrand()]);
       entries = brands.map((b) => ({
         url: `/brands/${b.slug}`,
-        lastmod: SITE_BUILD_DATE,
+        // Brand lastmod = newest color insertion date for this brand.
+        // Real "latest activity" signal per brand instead of a uniform build date.
+        lastmod: latestByBrand.get(b.slug) ?? SITE_BUILD_DATE,
       }));
     } else if (id.startsWith("colors-")) {
       const pageNum = Number(id.slice("colors-".length));
@@ -84,7 +86,9 @@ export async function GET(
       }
       entries = pageColors.map((c) => ({
         url: `/colors/${c.brandSlug}/${c.colorSlug}`,
-        lastmod: SITE_BUILD_DATE,
+        // Per-row created_at instead of a uniform build date — Google ignores
+        // lastmod fields that are identical across thousands of URLs.
+        lastmod: c.createdAt ? c.createdAt.split("T")[0] : SITE_BUILD_DATE,
       }));
     } else if (id === "matches") {
       // Brand-to-brand match landing pages — only major brand combinations
@@ -127,10 +131,10 @@ export async function GET(
         };
       });
     } else if (id === "families") {
-      const families = await getAllColorFamilies();
+      const [families, latestByFamily] = await Promise.all([getAllColorFamilies(), getLatestColorDateByFamily()]);
       entries = families.map((f) => ({
         url: `/colors/family/${f.slug}`,
-        lastmod: SITE_BUILD_DATE,
+        lastmod: latestByFamily.get(f.slug) ?? SITE_BUILD_DATE,
       }));
     } else if (id === "inspiration") {
       entries = inspirationPalettes.map((p) => ({

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -582,7 +582,7 @@ export async function getTopCrossBrandMatches(
 export async function getAllColorSlugs(options?: {
   perBrand?: number;
   brandSlugs?: string[];
-}): Promise<{ brandSlug: string; colorSlug: string }[]> {
+}): Promise<{ brandSlug: string; colorSlug: string; createdAt: string }[]> {
   const perBrand = options?.perBrand;
   const brandSlugs = options?.brandSlugs;
 
@@ -592,12 +592,12 @@ export async function getAllColorSlugs(options?: {
     const brands = brandSlugs
       ? allBrands.filter((b) => brandSlugs.includes(b.slug))
       : allBrands;
-    const results: { brandSlug: string; colorSlug: string }[] = [];
+    const results: { brandSlug: string; colorSlug: string; createdAt: string }[] = [];
 
     for (const brand of brands) {
       let query = supabase
         .from("colors")
-        .select("slug, brand:brand_id (slug)")
+        .select("slug, created_at, brand:brand_id (slug)")
         .eq("brand_id", brand.id)
         .order("name");
 
@@ -614,6 +614,7 @@ export async function getAllColorSlugs(options?: {
           results.push({
             brandSlug: brandData.slug,
             colorSlug: color.slug,
+            createdAt: color.created_at,
           });
         }
       }
@@ -623,7 +624,7 @@ export async function getAllColorSlugs(options?: {
   }
 
   // Fetch all colors (no limit)
-  const results: { brandSlug: string; colorSlug: string }[] = [];
+  const results: { brandSlug: string; colorSlug: string; createdAt: string }[] = [];
   const batchSize = 1000;
   let offset = 0;
   let hasMore = true;
@@ -631,7 +632,7 @@ export async function getAllColorSlugs(options?: {
   while (hasMore) {
     const { data, error } = await supabase
       .from("colors")
-      .select("slug, brand:brand_id (slug)")
+      .select("slug, created_at, brand:brand_id (slug)")
       .range(offset, offset + batchSize - 1);
 
     if (error) throw error;
@@ -645,6 +646,7 @@ export async function getAllColorSlugs(options?: {
       results.push({
         brandSlug: brandData.slug,
         colorSlug: color.slug,
+        createdAt: color.created_at,
       });
     }
 
@@ -655,4 +657,58 @@ export async function getAllColorSlugs(options?: {
   }
 
   return results;
+}
+
+// Latest color insertion date per brand (slug → ISO date YYYY-MM-DD). Used
+// for brand-page sitemap lastmod so each brand emits a real "latest activity"
+// signal instead of all 14 brand URLs sharing the same build date.
+// Paginates through the colors table because Supabase caps single-request
+// returns at 1000 rows by default and the table has 23k+ rows.
+export async function getLatestColorDateByBrand(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const batchSize = 1000;
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("colors")
+      .select("created_at, brand:brand_id (slug)")
+      .range(offset, offset + batchSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      const brandSlug = (row.brand as unknown as { slug: string }).slug;
+      const date = row.created_at.split("T")[0];
+      const existing = map.get(brandSlug);
+      if (!existing || date > existing) map.set(brandSlug, date);
+    }
+    if (data.length < batchSize) break;
+    offset += batchSize;
+  }
+  return map;
+}
+
+// Latest color insertion date per color family (family slug → ISO date).
+// Same purpose as getLatestColorDateByBrand but keyed on color_family.
+export async function getLatestColorDateByFamily(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const batchSize = 1000;
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("colors")
+      .select("created_at, color_family")
+      .not("color_family", "is", null)
+      .range(offset, offset + batchSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      if (!row.color_family) continue;
+      const date = row.created_at.split("T")[0];
+      const existing = map.get(row.color_family);
+      if (!existing || date > existing) map.set(row.color_family, date);
+    }
+    if (data.length < batchSize) break;
+    offset += batchSize;
+  }
+  return map;
 }


### PR DESCRIPTION
## Summary

M3 from the 2026-05-12 audit. Every color, brand, and family URL was emitting the same \`SITE_BUILD_DATE\` for \`<lastmod>\` — Google progressively ignores sitemap fields that don't vary across thousands of URLs.

**What changes:**
- \`/colors/[brand]/[slug]\` → \`color.created_at\`
- \`/brands/[brand]\` → MAX(created_at) across that brand's colors
- \`/colors/family/[fam]\` → MAX(created_at) across that family's colors

Today the colors table has 3 distinct created_at dates: 2026-02-10 (bulk 23,091 rows), 2026-03-20 (339-row SW + Valspar refresh), 2026-02-17 (8 BM rows). That's enough variation that Google sees real per-URL recency signal — not perfect (the deeper fix needs an \`updated_at\` column + match-recompute timestamps), but honest and meaningful for the brand/family hubs.

## Per-brand lastmod after this change

| Brand | lastmod |
|---|---|
| SW, Valspar | 2026-03-20 |
| Benjamin Moore | 2026-02-17 |
| All other 11 brands | 2026-02-10 |

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/sitemap/colors-0\` includes per-row lastmod values (not all SITE_BUILD_DATE)
- [ ] \`/sitemap/brands\` shows \`sherwin-williams\` lastmod = 2026-03-20, \`benjamin-moore\` = 2026-02-17, others = 2026-02-10
- [ ] \`/sitemap/families\` shows varied lastmods across the 15 family URLs

## Tracked follow-up

The agent's deeper fix (per-color \`updated_at\` + match recompute timestamps) needs a Supabase schema migration. Saving for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)