### PR TITLE
seo(schema+geo): BreadcrumbList item + Offer block + brand-pair FAQ + visible family FAQ

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -528,6 +528,18 @@ export default async function ColorPage({ params }: PageProps) {
           ...(color.undertone ? [{ "@type": "PropertyValue", name: "Undertone", value: color.undertone }] : []),
           ...(color.color_family ? [{ "@type": "PropertyValue", name: "Color Family", value: color.color_family }] : []),
         ],
+        // Minimal Offer block — `price` deliberately omitted because paint
+        // pricing varies by store, region, and sheen (a wrong price triggers
+        // Google manual actions). InStoreOnly availability + named seller
+        // is enough to unlock Product rich-result eligibility across all
+        // ~23k color pages.
+        offers: {
+          "@type": "Offer",
+          availability: "https://schema.org/InStoreOnly",
+          priceCurrency: "USD",
+          seller: { "@type": "Organization", name: color.brand.name },
+          url: `https://www.paintcolorhq.com/colors/${brandSlug}/${colorSlug}`,
+        },
         ...(matches.length > 0 && {
           isSimilarTo: matches
             .filter((m) => Number(m.delta_e_score) < 2)

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -240,6 +240,49 @@ export default async function ColorFamilyPage({ params }: PageProps) {
         </div>
       </section>
 
+      {/* FAQ — rendered as visible HTML in addition to the FAQPage JSON-LD
+          above. Perplexity, AI Overviews, and ChatGPT primarily extract
+          from visible DOM text rather than schema, so the family-specific
+          undertone copy (M1) plus count and matching guidance need to be
+          on-page, not schema-only. */}
+      <section className="py-20 px-6 md:px-12 bg-surface">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="font-headline text-3xl font-bold text-on-surface tracking-tight mb-8">
+            {familyName} Paint Colors — Frequently Asked Questions
+          </h2>
+          <div className="space-y-4">
+            <details className="group bg-surface-container-lowest rounded-xl border border-outline-variant/10">
+              <summary className="flex cursor-pointer items-center justify-between px-6 py-5 font-headline font-bold text-on-surface hover:text-primary transition-colors">
+                How many {familyName.toLowerCase()} paint colors are catalogued?
+                <svg className="h-5 w-5 shrink-0 text-outline transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
+              </summary>
+              <div className="px-6 pb-5 text-on-surface-variant leading-relaxed">
+                Paint Color HQ catalogs {totalCount.toLocaleString()} {familyName.toLowerCase()} paint colors across {brandCount} major brands, including Sherwin-Williams, Benjamin Moore, Behr, Valspar, PPG, Dunn-Edwards, and Farrow & Ball.
+              </div>
+            </details>
+            <details className="group bg-surface-container-lowest rounded-xl border border-outline-variant/10">
+              <summary className="flex cursor-pointer items-center justify-between px-6 py-5 font-headline font-bold text-on-surface hover:text-primary transition-colors">
+                What undertones do {familyName.toLowerCase()} paint colors have?
+                <svg className="h-5 w-5 shrink-0 text-outline transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
+              </summary>
+              <div className="px-6 pb-5 text-on-surface-variant leading-relaxed">
+                {FAMILY_UNDERTONE_ANSWERS[familySlug] ??
+                  `${familyName} paint colors come in warm undertones (leaning yellower, redder, or browner), cool undertones (leaning bluer or greener), and balanced neutrals. Use the undertone filter above to narrow your search.`}
+              </div>
+            </details>
+            <details className="group bg-surface-container-lowest rounded-xl border border-outline-variant/10">
+              <summary className="flex cursor-pointer items-center justify-between px-6 py-5 font-headline font-bold text-on-surface hover:text-primary transition-colors">
+                How do I find a {familyName.toLowerCase()} paint color that matches across brands?
+                <svg className="h-5 w-5 shrink-0 text-outline transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
+              </summary>
+              <div className="px-6 pb-5 text-on-surface-variant leading-relaxed">
+                Every color page on Paint Color HQ shows cross-brand matches ranked by CIEDE2000 Delta E score. Colors with a Delta E under 2.0 are virtually identical on a finished wall. Click any color in the grid above to see its closest matches across all {brandCount} brands.
+              </div>
+            </details>
+          </div>
+        </div>
+      </section>
+
       {/* Inspiration Featuring [Family] — closes the family -> inspiration
           cluster gap the audit flagged. Cards link to curated palettes that
           prominently feature this color family. */}

--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -121,7 +121,7 @@ export default async function MatchPage({ params }: PageProps) {
       <JsonLd data={{ "@context": "https://schema.org", "@type": "BreadcrumbList", itemListElement: [
         { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },
         { "@type": "ListItem", position: 2, name: sourceColor.name, item: `https://www.paintcolorhq.com/colors/${sourceColor.brand.slug}/${sourceColor.slug}` },
-        { "@type": "ListItem", position: 3, name: `Match in ${targetBrand.name}` },
+        { "@type": "ListItem", position: 3, name: `${targetBrand.name} Equivalent`, item: `https://www.paintcolorhq.com/match/${sourceBrandSlug}/${parsed.colorSlug}-to-${parsed.targetBrandSlug}` },
       ]}} />
       {bestMatch && <JsonLd data={{ "@context": "https://schema.org", "@type": "FAQPage", mainEntity: [
         { "@type": "Question", name: `What is the ${targetBrand.name} equivalent of ${sourceColor.brand.name} ${sourceColor.name}?`,

--- a/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
@@ -202,6 +202,30 @@ export default async function BrandToBrandMatchPage({ params }: PageProps) {
           { "@type": "ListItem", position: 4, name: `${sourceBrand.name} to ${targetBrand.name}`, item: `https://www.paintcolorhq.com/match/${sourceBrandSlug}/to/${targetBrandSlug}` },
         ],
       }} />
+      {/* FAQPage for AI engine citation. Data-grounded answers from values
+          already in scope — match count for this brand pair, plus the
+          Delta E methodology explainer. */}
+      <JsonLd data={{
+        "@context": "https://schema.org", "@type": "FAQPage",
+        mainEntity: [
+          {
+            "@type": "Question",
+            name: `How many ${sourceBrand.name} colors have a ${targetBrand.name} equivalent?`,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: `Paint Color HQ has identified ${matches.length} close ${sourceBrand.name}-to-${targetBrand.name} color matches ranked by CIEDE2000 Delta E score. Colors with a Delta E under 2.0 are virtually identical on a finished wall; under 5.0 are visibly similar.`,
+            },
+          },
+          {
+            "@type": "Question",
+            name: `What is the best way to match ${sourceBrand.name} paint colors to ${targetBrand.name}?`,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: `Use the Delta E color difference score. A Delta E under 2.0 means the colors are nearly identical on a finished wall; under 5.0 means visibly similar but distinguishable. Always verify with physical paint samples in your room's actual lighting before committing — small differences amplify at scale.`,
+            },
+          },
+        ],
+      }} />
 
       <AdSenseScript />
       <Footer />


### PR DESCRIPTION
## Summary

Four schema + GEO findings from the 2026-05-13 re-audit.

| # | Item | Impact |
|---|---|---|
| 1 | Match detail BreadcrumbList position 3 missing \`item\` URL | Google now surfaces breadcrumb trails for ~280 popular cross-brand pairs |
| 2 | Color page Product schema gained an \`offers\` block | Rich-result eligibility across all ~23k color pages (no \`price\` field; \`InStoreOnly\` only — safe) |
| 3 | Brand-to-brand match listing pages now emit FAQPage schema | 42 high-intent pages join the AI-citation set |
| 4 | Family hub FAQ rendered as visible \`<details>\`/\`<summary>\` HTML | PR #57's family-specific undertone copy now reachable by DOM-extraction crawlers (Perplexity, AI Overviews) — was schema-only before |

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/match/sherwin-williams/agreeable-gray-7029-to-behr\` BreadcrumbList JSON-LD has \`item\` URL on position 3
- [ ] \`/colors/sherwin-williams/agreeable-gray-7029\` Product JSON-LD has an \`offers\` block with \`seller.name = "Sherwin-Williams"\`
- [ ] \`/match/behr/to/valspar\` HTML contains FAQPage JSON-LD with two questions about Delta E + match count
- [ ] \`/colors/family/gray\` HTML contains a visible "{familyName} Paint Colors — Frequently Asked Questions" section with 3 collapsible items including the gray-specific undertone copy
- [ ] Family hub cache headers still \`HIT\` (no ISR regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)