### PR TITLE
seo(linkgraph): related-reading on match listings + complete footer family list

### DIFF
--- a/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
@@ -187,6 +187,61 @@ export default async function BrandToBrandMatchPage({ params }: PageProps) {
         </div>
       </section>
 
+      {/* Related reading — closes the cluster gap the audit flagged:
+          /match/[a]/to/[b] pages had zero outbound editorial links into the
+          blog cluster despite being high-intent commercial pages. Methodology
+          post is universal; the brand-comparison post is conditional on the
+          pair containing SW, BM, or Behr. */}
+      <section className="py-16 px-6 md:px-12 bg-surface-container-low">
+        <div className="max-w-7xl mx-auto">
+          <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-6">
+            Related Reading
+          </h2>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Link
+              href="/blog/how-to-find-perfect-color-match-across-brands"
+              className="group bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all"
+            >
+              <p className="text-[10px] uppercase tracking-widest text-outline font-bold mb-2">Methodology</p>
+              <p className="font-headline text-lg font-bold text-on-surface group-hover:text-primary transition-colors">
+                How to find the perfect paint color match across brands
+              </p>
+              <p className="mt-2 text-sm text-on-surface-variant">
+                The CIEDE2000 Delta E score, how to read the verdict labels, and what changes between cross-brand pairs.
+              </p>
+            </Link>
+            {(() => {
+              const pair = `${sourceBrandSlug}|${targetBrandSlug}`;
+              if (pair === "sherwin-williams|benjamin-moore" || pair === "benjamin-moore|sherwin-williams") {
+                return (
+                  <Link href="/blog/sherwin-williams-vs-benjamin-moore" className="group bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all">
+                    <p className="text-[10px] uppercase tracking-widest text-outline font-bold mb-2">Comparison</p>
+                    <p className="font-headline text-lg font-bold text-on-surface group-hover:text-primary transition-colors">Sherwin-Williams vs. Benjamin Moore: full brand comparison</p>
+                    <p className="mt-2 text-sm text-on-surface-variant">Price, color depth, finish quality, and where each brand wins.</p>
+                  </Link>
+                );
+              }
+              if ([sourceBrandSlug, targetBrandSlug].every((s) => ["sherwin-williams", "benjamin-moore", "behr"].includes(s))) {
+                return (
+                  <Link href="/blog/behr-vs-sherwin-williams-vs-benjamin-moore" className="group bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all">
+                    <p className="text-[10px] uppercase tracking-widest text-outline font-bold mb-2">Comparison</p>
+                    <p className="font-headline text-lg font-bold text-on-surface group-hover:text-primary transition-colors">Behr vs. Sherwin-Williams vs. Benjamin Moore</p>
+                    <p className="mt-2 text-sm text-on-surface-variant">Three-way comparison of the most cross-shopped consumer paint brands.</p>
+                  </Link>
+                );
+              }
+              return (
+                <Link href="/blog/understanding-paint-color-undertones" className="group bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10 hover:shadow-lg transition-all">
+                  <p className="text-[10px] uppercase tracking-widest text-outline font-bold mb-2">Color Theory</p>
+                  <p className="font-headline text-lg font-bold text-on-surface group-hover:text-primary transition-colors">Understanding paint color undertones</p>
+                  <p className="mt-2 text-sm text-on-surface-variant">Why a perfect Delta E match can still look wrong on the wall — and how to read undertones before you commit.</p>
+                </Link>
+              );
+            })()}
+          </div>
+        </div>
+      </section>
+
       <JsonLd data={{
         "@context": "https://schema.org", "@type": "ItemList",
         name: `${sourceBrand.name} to ${targetBrand.name} Equivalent Colors`,

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -69,8 +69,11 @@ export function Footer() {
           </ul>
 
           <h4 className="font-headline text-[10px] uppercase font-bold text-on-surface mb-4 mt-8 tracking-widest">Color Families</h4>
-          <div className="flex flex-wrap gap-2">
-            {["White", "Gray", "Beige", "Blue", "Green", "Red", "Yellow", "Black"].map((family) => (
+          <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+            {[
+              "White", "Off-White", "Gray", "Beige", "Neutral", "Brown", "Tan",
+              "Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Pink", "Black",
+            ].map((family) => (
               <Link
                 key={family}
                 href={`/colors/family/${family.toLowerCase()}`}


### PR DESCRIPTION
## Summary

Two link-graph gaps from the 2026-05-12 cluster audit. (The audit also flagged "brand pages don't link to blog posts" and "sitemap missing /about/contact/faq" — both verified already-addressed before this change.)

### Match listing → blog

42 brand-to-brand listing pages had zero outbound links into the blog cluster despite being high-intent commercial pages. Added a "Related Reading" section that always shows the universal methodology post plus one contextual pair-specific link:

- SW ↔ BM → \`sherwin-williams-vs-benjamin-moore\`
- Any combo of SW/BM/Behr → \`behr-vs-sherwin-williams-vs-benjamin-moore\`
- Otherwise → \`understanding-paint-color-undertones\` (covers Delta E ≠ visual identity)

### Footer family list

Footer linked to 8 of 15 families (White, Gray, Beige, Blue, Green, Red, Yellow, Black). Added the missing 7 (Off-White, Neutral, Brown, Tan, Orange, Purple, Pink).

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/match/sherwin-williams/to/benjamin-moore\` shows Related Reading with the SW-vs-BM blog card
- [ ] \`/match/behr/to/sherwin-williams\` shows the three-way comparison card
- [ ] \`/match/farrow-ball/to/sherwin-williams\` shows the undertones card (default fallback)
- [ ] Footer on any page shows all 15 family links

🤖 Generated with [Claude Code](https://claude.com/claude-code)