### PR TITLE
seo(cleanup): og:url default + BlogPosting image fallback + dedupe non-www redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -65,12 +65,10 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
-      {
-        source: "/:path*",
-        has: [{ type: "host", value: "paintcolorhq.com" }],
-        destination: "https://www.paintcolorhq.com/:path*",
-        permanent: true,
-      },
+      // Non-www → www redirect lives in vercel.json (the Vercel edge layer
+      // processes those before Next.js rewrites, so a redirect here is dead
+      // code). Keeping the path-level redirects below since vercel.json
+      // doesn't carry them.
       {
         source: "/colors/family/taupe",
         destination: "/colors/family/beige",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -213,7 +213,17 @@ export default async function BlogPostPage({ params }: PageProps) {
         description: post.excerpt, url: `https://www.paintcolorhq.com/blog/${post.slug}`,
         mainEntityOfPage: { "@type": "WebPage", "@id": `https://www.paintcolorhq.com/blog/${post.slug}` },
         keywords: post.tags.join(", "),
-        ...(post.coverImage && { image: { "@type": "ImageObject", url: `https://www.paintcolorhq.com${post.coverImage}`, width: 1200, height: 630 } }),
+        // Always emit `image`. Posts without a coverImage fall back to the
+        // generated /api/og endpoint — satisfies the BlogPosting recommended
+        // property without forcing a stock image per post.
+        image: {
+          "@type": "ImageObject",
+          url: post.coverImage
+            ? `https://www.paintcolorhq.com${post.coverImage}`
+            : `https://www.paintcolorhq.com/api/og?name=${encodeURIComponent(post.title)}&brand=${encodeURIComponent("Paint Color HQ")}`,
+          width: 1200,
+          height: 630,
+        },
         author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Founder, Paint Color HQ", worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
         publisher: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com", logo: { "@type": "ImageObject", url: "https://www.paintcolorhq.com/logo.webp", width: 600, height: 60 } },
       }} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,9 @@ export const metadata: Metadata = {
     title: "Match Any Paint Color Across 14 Brands | Paint Color HQ",
     description:
       "Free paint color cross-reference tool. Match any color across Sherwin-Williams, Benjamin Moore, Behr & 11 more brands. 23,000+ colors with room visualizer, photo color identifier & paint calculator.",
+    // Default og:url for pages that don't set their own. Per-page metadata
+    // (color, brand, family, blog) overrides this with the canonical URL.
+    url: "https://www.paintcolorhq.com",
     images: [{ url: "/og-image.webp", width: 1200, height: 630 }],
   },
   twitter: {


### PR DESCRIPTION
## Summary

Three cleanups from the 2026-05-13 re-audit. All small, low-risk, no UX change.

1. **og:url default in layout** — pages that don't set their own \`openGraph.url\` (e.g. \`/colors\`, \`/search\`, \`/compare\`, \`/brands\` index) now inherit a default. Per-page overrides still take precedence on color/brand/family/blog/match URLs.

2. **BlogPosting image fallback** — was conditional on \`post.coverImage\`; posts without one emitted no \`image\` at all. Now falls back to \`/api/og\` (same generated endpoint other page types use).

3. **Dedupe non-www → www redirect** — was defined in both \`vercel.json\` and \`next.config.ts\`. Vercel processes \`vercel.json\` redirects before Next.js so the next.config.ts version was dead code. Removed the duplicate; kept vercel.json (active layer) and the path-level redirects below it in next.config.ts.

## Test plan

- [ ] Preview deploy succeeds
- [ ] \`/compare\` HTML includes \`<meta property="og:url"\`
- [ ] Any blog post emits \`image\` in BlogPosting JSON-LD even when \`coverImage\` is undefined
- [ ] Non-www → www redirect still works (\`paintcolorhq.com/colors/family/blue\` → \`www.paintcolorhq.com/colors/family/blue\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)