### PR TITLE
feat(pinterest): automated generate + publish pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ client_secret_*.json
 scripts/drift/*.db
 scripts/drift/*.db-shm
 scripts/drift/*.db-wal
+
+# Pinterest runtime publish state (pin IDs, not secrets, but runtime-only)
+scripts/pinterest/published-*.json

--- a/scripts/pinterest-auth.ts
+++ b/scripts/pinterest-auth.ts
@@ -1,0 +1,146 @@
+/**
+ * Pinterest OAuth — one-time token mint.
+ *
+ * The dashboard "Generate token" button only grants READ scopes. To publish
+ * pins we need pins:write, which requires the full OAuth authorization flow.
+ * This script runs that flow locally:
+ *
+ *   1. Spins up a localhost listener on REDIRECT (default :8732).
+ *   2. Opens the Pinterest consent screen requesting the scopes we need.
+ *   3. Catches the redirect ?code=..., exchanges it (App ID + secret) for an
+ *      access token + refresh token, and writes both back to .env.local.
+ *
+ * PREREQUISITE — add this exact redirect URI in the Pinterest app dashboard
+ * (Redirect URIs section), or the consent screen will reject the request:
+ *
+ *   http://localhost:8732/callback
+ *
+ * Run:  npx tsx scripts/pinterest-auth.ts
+ */
+import * as http from "http";
+import * as path from "path";
+import * as fs from "fs";
+import { randomBytes } from "crypto";
+import { execFile } from "child_process";
+import { fileURLToPath } from "url";
+import * as dotenv from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ENV_PATH = path.resolve(__dirname, "../.env.local");
+dotenv.config({ path: ENV_PATH });
+
+const APP_ID = process.env.PINTEREST_APP_ID;
+const APP_SECRET = process.env.PINTEREST_APP_SECRET_KEY;
+const PORT = 8732;
+const REDIRECT = `http://localhost:${PORT}/callback`;
+const SCOPES = ["boards:read", "boards:write", "pins:read", "pins:write", "user_accounts:read"];
+
+if (!APP_ID || !APP_SECRET) {
+  console.error("Missing PINTEREST_APP_ID or PINTEREST_APP_SECRET_KEY in .env.local");
+  process.exit(1);
+}
+
+/** Upsert a KEY=value line in .env.local, preserving everything else. */
+function upsertEnv(updates: Record<string, string>) {
+  let lines = fs.readFileSync(ENV_PATH, "utf8").split("\n");
+  for (const [key, value] of Object.entries(updates)) {
+    const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+    const line = `${key}=${value}`;
+    if (idx >= 0) lines[idx] = line;
+    else lines.push(line);
+  }
+  fs.writeFileSync(ENV_PATH, lines.join("\n"));
+}
+
+async function exchangeCode(code: string) {
+  const basic = Buffer.from(`${APP_ID}:${APP_SECRET}`).toString("base64");
+  const res = await fetch("https://api.pinterest.com/v5/oauth/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: REDIRECT,
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Token exchange failed (${res.status}): ${JSON.stringify(data)}`);
+  return data as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    refresh_token_expires_in?: number;
+    scope: string;
+  };
+}
+
+const state = randomBytes(16).toString("hex");
+const authUrl =
+  "https://www.pinterest.com/oauth/?" +
+  new URLSearchParams({
+    client_id: APP_ID,
+    redirect_uri: REDIRECT,
+    response_type: "code",
+    scope: SCOPES.join(","),
+    state,
+  });
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+  if (url.pathname !== "/callback") {
+    res.writeHead(404).end("Not found");
+    return;
+  }
+  const code = url.searchParams.get("code");
+  const returnedState = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) {
+    res.writeHead(400).end(`Authorization denied: ${error}`);
+    console.error(`\n❌ Authorization denied: ${error}`);
+    server.close();
+    process.exit(1);
+  }
+  if (returnedState !== state) {
+    res.writeHead(400).end("State mismatch — possible CSRF. Aborted.");
+    console.error("\n❌ State mismatch. Aborted.");
+    server.close();
+    process.exit(1);
+  }
+  if (!code) {
+    res.writeHead(400).end("No code in callback.");
+    return;
+  }
+
+  try {
+    const token = await exchangeCode(code);
+    upsertEnv({
+      PINTEREST_ACCESS_TOKEN: token.access_token,
+      PINTEREST_REFRESH_TOKEN: token.refresh_token,
+    });
+    res.writeHead(200, { "Content-Type": "text/html" }).end(
+      "<h2>✅ Pinterest authorized.</h2><p>Tokens saved to .env.local. You can close this tab and return to the terminal.</p>"
+    );
+    const days = token.expires_in ? Math.round(token.expires_in / 86400) : "?";
+    console.log("\n✅ Authorized and saved to .env.local");
+    console.log(`   Scopes:  ${token.scope}`);
+    console.log(`   Access token expires in ~${days} days (refresh token saved for renewal).`);
+    server.close();
+    process.exit(0);
+  } catch (e) {
+    res.writeHead(500).end(String(e));
+    console.error("\n❌", e);
+    server.close();
+    process.exit(1);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log("Pinterest OAuth — requesting scopes:", SCOPES.join(", "));
+  console.log(`\nIf your browser doesn't open, paste this URL:\n\n${authUrl}\n`);
+  execFile("open", [authUrl]); // macOS — no shell, URL passed as a single arg
+});

--- a/scripts/pinterest-generate.ts
+++ b/scripts/pinterest-generate.ts
@@ -1,0 +1,90 @@
+/**
+ * Pinterest image generator — Nano Banana (gemini-3-pro-image).
+ *
+ * Generates each pin image from its prompt in batch-may26.ts at a 2:3 vertical
+ * aspect ratio and saves it into IMAGE_DIR using the batch's image filename.
+ *
+ * Each call is its own fresh API context — which structurally eliminates the
+ * long-chat context-contamination failure mode you get in the web app.
+ *
+ * Workflow: run this, then have Claude read the PNGs and QA the swatch text
+ * against the spec. Regenerate any that fail with --only=<ids> --force until
+ * they pass. Each generation costs cents, so retries are cheap.
+ *
+ * Usage:
+ *   npx tsx scripts/pinterest-generate.ts --only=3        # generate pin 3
+ *   npx tsx scripts/pinterest-generate.ts --only=3 --force # overwrite existing
+ *   npx tsx scripts/pinterest-generate.ts                 # all missing images
+ *   npx tsx scripts/pinterest-generate.ts --force         # regenerate everything
+ */
+import * as path from "path";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import * as dotenv from "dotenv";
+import { BATCH, IMAGE_DIR, type PinSpec } from "./pinterest/batch-may26.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, "../.env.local") });
+
+const API_KEY = process.env.GEMINI_API_KEY;
+const MODEL = "gemini-3-pro-image";
+
+if (!API_KEY) {
+  console.error("Missing GEMINI_API_KEY in .env.local");
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const FORCE = args.includes("--force");
+const onlyArg = args.find((a) => a.startsWith("--only="));
+const onlyIds = onlyArg
+  ? new Set(onlyArg.replace("--only=", "").split(",").map((n) => parseInt(n, 10)))
+  : null;
+
+async function generate(pin: PinSpec) {
+  const out = path.join(IMAGE_DIR, pin.image);
+  if (fs.existsSync(out) && !FORCE && !onlyIds) {
+    console.log(`⏭️  #${pin.id} ${pin.name} — exists (use --force to overwrite)`);
+    return;
+  }
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${API_KEY}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: pin.prompt }] }],
+      generationConfig: {
+        responseModalities: ["IMAGE"],
+        imageConfig: { aspectRatio: "2:3" },
+      },
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`${res.status}: ${JSON.stringify(data).slice(0, 400)}`);
+  const parts = data?.candidates?.[0]?.content?.parts ?? [];
+  const img = parts.find((p: any) => p.inlineData)?.inlineData;
+  if (!img) {
+    const text = parts.find((p: any) => p.text)?.text;
+    throw new Error(`No image returned${text ? ` — model said: ${text.slice(0, 200)}` : ""}`);
+  }
+  fs.mkdirSync(IMAGE_DIR, { recursive: true });
+  fs.writeFileSync(out, Buffer.from(img.data, "base64"));
+  const mb = (Buffer.from(img.data, "base64").length / 1024 / 1024).toFixed(1);
+  console.log(`✅ #${pin.id} ${pin.name} → ${pin.image} (${img.mimeType}, ${mb}MB)`);
+}
+
+async function main() {
+  const targets = BATCH.filter((p) => (onlyIds ? onlyIds.has(p.id) : true));
+  console.log(`Generating ${targets.length} image(s) with ${MODEL} at 2:3\n`);
+  for (const pin of targets) {
+    try {
+      await generate(pin);
+    } catch (e) {
+      console.error(`❌ #${pin.id} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  console.log("\nDone. Next: have Claude QA the images, then publish.");
+}
+
+main();

--- a/scripts/pinterest-publish.ts
+++ b/scripts/pinterest-publish.ts
@@ -1,0 +1,167 @@
+/**
+ * Pinterest publisher — creates pins from the batch definition + local images.
+ *
+ * Reads scripts/pinterest/batch-may26.ts, matches each pin to its PNG in
+ * IMAGE_DIR, base64-encodes it, and POSTs to /v5/pins on the correct board
+ * with title / description / UTM link.
+ *
+ * Requires an OAuth access token with pins:write (run pinterest-auth.ts first).
+ * Auto-refreshes the access token on 401 using PINTEREST_REFRESH_TOKEN.
+ *
+ * A publish log (scripts/pinterest/published-may26.json) records pin id ->
+ * Pinterest pin id so re-runs never double-post.
+ *
+ * Usage:
+ *   npx tsx scripts/pinterest-publish.ts --dry-run     # validate, no POST
+ *   npx tsx scripts/pinterest-publish.ts --only=1,3    # publish pins 1 and 3
+ *   npx tsx scripts/pinterest-publish.ts               # publish all unpublished
+ */
+import * as path from "path";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import * as dotenv from "dotenv";
+import { BATCH, BOARD_IDS, IMAGE_DIR, type PinSpec } from "./pinterest/batch-may26.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ENV_PATH = path.resolve(__dirname, "../.env.local");
+const LOG_PATH = path.resolve(__dirname, "pinterest/published-may26.json");
+dotenv.config({ path: ENV_PATH });
+
+const APP_ID = process.env.PINTEREST_APP_ID!;
+const APP_SECRET = process.env.PINTEREST_APP_SECRET_KEY!;
+const API = "https://api.pinterest.com/v5";
+
+// ---- CLI args ----
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const onlyArg = args.find((a) => a.startsWith("--only="));
+const onlyIds = onlyArg
+  ? new Set(onlyArg.replace("--only=", "").split(",").map((n) => parseInt(n, 10)))
+  : null;
+
+// ---- env + log helpers ----
+function upsertEnv(updates: Record<string, string>) {
+  let lines = fs.readFileSync(ENV_PATH, "utf8").split("\n");
+  for (const [key, value] of Object.entries(updates)) {
+    const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+    const line = `${key}=${value}`;
+    if (idx >= 0) lines[idx] = line;
+    else lines.push(line);
+  }
+  fs.writeFileSync(ENV_PATH, lines.join("\n"));
+}
+
+type PublishLog = Record<string, { pinId: string; publishedAt: string }>;
+function loadLog(): PublishLog {
+  try {
+    return JSON.parse(fs.readFileSync(LOG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function saveLog(log: PublishLog) {
+  fs.writeFileSync(LOG_PATH, JSON.stringify(log, null, 2) + "\n");
+}
+
+let accessToken = process.env.PINTEREST_ACCESS_TOKEN!;
+
+async function refreshAccessToken(): Promise<void> {
+  const refresh = process.env.PINTEREST_REFRESH_TOKEN;
+  if (!refresh) throw new Error("401 and no PINTEREST_REFRESH_TOKEN — re-run pinterest-auth.ts");
+  const basic = Buffer.from(`${APP_ID}:${APP_SECRET}`).toString("base64");
+  const res = await fetch(`${API}/oauth/token`, {
+    method: "POST",
+    headers: { Authorization: `Basic ${basic}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: refresh }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Token refresh failed (${res.status}): ${JSON.stringify(data)}`);
+  accessToken = data.access_token;
+  const updates: Record<string, string> = { PINTEREST_ACCESS_TOKEN: data.access_token };
+  if (data.refresh_token) updates.PINTEREST_REFRESH_TOKEN = data.refresh_token;
+  upsertEnv(updates);
+  console.log("   ↻ refreshed access token");
+}
+
+async function pinterest(pathname: string, init: RequestInit, retry = true): Promise<any> {
+  const res = await fetch(`${API}${pathname}`, {
+    ...init,
+    headers: { ...(init.headers ?? {}), Authorization: `Bearer ${accessToken}` },
+  });
+  const data = await res.json().catch(() => ({}));
+  // Only refresh on an expired/invalid token — NOT on a scope error (also 401).
+  const isScopeError = typeof data?.message === "string" && /scope|Missing:/i.test(data.message);
+  if (res.status === 401 && retry && !isScopeError) {
+    await refreshAccessToken();
+    return pinterest(pathname, init, false);
+  }
+  if (!res.ok) throw new Error(`${res.status} ${pathname}: ${JSON.stringify(data)}`);
+  return data;
+}
+
+function imagePayload(pin: PinSpec) {
+  const file = path.join(IMAGE_DIR, pin.image);
+  if (!fs.existsSync(file)) throw new Error(`Image not found: ${file}`);
+  const buf = fs.readFileSync(file);
+  // Sniff content type from magic bytes — the file extension can lie
+  // (gemini-3-pro-image returns JPEG even when we save as .png).
+  let contentType = "image/png";
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) contentType = "image/jpeg";
+  else if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) contentType = "image/png";
+  return { source_type: "image_base64" as const, content_type: contentType, data: buf.toString("base64") };
+}
+
+async function publishPin(pin: PinSpec, log: PublishLog) {
+  const tag = `#${pin.id} ${pin.name}`;
+  if (log[pin.id]) {
+    console.log(`⏭️  ${tag} — already published (pin ${log[pin.id].pinId})`);
+    return;
+  }
+  const boardId = BOARD_IDS[pin.board];
+  const media = imagePayload(pin); // validates file exists + reads bytes
+
+  if (DRY_RUN) {
+    console.log(`🧪 ${tag}`);
+    console.log(`     board:  ${pin.board} (${boardId})`);
+    console.log(`     title:  ${pin.title}  [${pin.title.length} chars]`);
+    console.log(`     link:   ${pin.link}`);
+    console.log(`     image:  ${pin.image} (${media.content_type}, ${(media.data.length / 1.37 / 1024 / 1024).toFixed(1)}MB)`);
+    return;
+  }
+
+  const result = await pinterest("/pins", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      board_id: boardId,
+      title: pin.title,
+      description: pin.description,
+      link: pin.link,
+      media_source: media,
+    }),
+  });
+  log[pin.id] = { pinId: result.id, publishedAt: new Date().toISOString() };
+  saveLog(log);
+  console.log(`✅ ${tag} → pin ${result.id} on ${pin.board}`);
+}
+
+async function main() {
+  const log = loadLog();
+  const targets = BATCH.filter((p) => (onlyIds ? onlyIds.has(p.id) : true));
+  console.log(
+    `${DRY_RUN ? "DRY RUN — " : ""}Publishing ${targets.length} pin(s)${onlyIds ? ` (--only=${[...onlyIds].join(",")})` : ""}\n`
+  );
+  for (const pin of targets) {
+    try {
+      await publishPin(pin, log);
+    } catch (e) {
+      console.error(`❌ #${pin.id} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+    }
+    // gentle spacing to stay clear of rate limits
+    if (!DRY_RUN) await new Promise((r) => setTimeout(r, 2500));
+  }
+  console.log("\nDone.");
+}
+
+main();

--- a/scripts/pinterest/batch-may26.ts
+++ b/scripts/pinterest/batch-may26.ts
@@ -1,0 +1,164 @@
+// Pinterest batch — May 2026 cohort (campaign: may26-pin-batch)
+// Single source of truth for both image generation and publishing.
+// Mirrors ~/Brain-Personal/10-projects/paintcolorhq/pinterest-may26-pin-batch.md
+
+export type BoardName =
+  | "Color Palettes"
+  | "Paint Color Guides"
+  | "Paint Colors"
+  | "Color Comparisons";
+
+// Pinterest board IDs for the paintcolorhq account (verified via GET /v5/boards).
+export const BOARD_IDS: Record<BoardName, string> = {
+  "Color Palettes": "1116681738796524225",
+  "Paint Color Guides": "1116681738796524227",
+  "Paint Colors": "1116681738796524224",
+  "Color Comparisons": "1116681738796524226",
+};
+
+export interface PinSpec {
+  /** 1-based position in the batch. */
+  id: number;
+  /** Human label. */
+  name: string;
+  /** Image filename inside IMAGE_DIR (matches the existing Desktop PNGs). */
+  image: string;
+  /** Full Gemini image-generation prompt (with rendering rules folded in). */
+  prompt: string;
+  /** Pinterest pin title. */
+  title: string;
+  /** Pinterest pin description. */
+  description: string;
+  /** UTM-tagged destination link. */
+  link: string;
+  /** Target board. */
+  board: BoardName;
+}
+
+/** Where the generated / source PNGs live. */
+export const IMAGE_DIR = "/Users/philipcameron/Desktop/Pinterest pins";
+
+const UTM = "?utm_source=Pinterest&utm_medium=organic&utm_campaign=may26-pin-batch";
+
+export const BATCH: PinSpec[] = [
+  {
+    id: 1,
+    name: "Hale Navy Living Room",
+    image: "Hale Navy Living Room.png",
+    prompt:
+      "Vertical 2:3 pin showing a mid-century modern living room. The accent wall behind the sofa is painted Hale Navy. The ceiling, door trim, and window casing are White Dove. The adjacent side wall (visible at the left edge near the window) is painted Edgecomb Gray. Furnishings: brass floor lamp, walnut credenza, cream linen sofa, woven jute rug, hanging brass pendant. Natural light from a left-side window. Three color swatches overlay the bottom-left corner: Hale Navy (HEX #3E4450, RGB 62, 68, 80, LRV 7.1, Undertone Cool), White Dove (HEX #EDE6D3, RGB 237, 230, 211, LRV 83, Undertone Warm), Edgecomb Gray (HEX #D3CBBA, RGB 211, 203, 186, LRV 66, Undertone Warm Neutral) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Hale Navy Living Room — Benjamin Moore HC-154 Paint Color Palette",
+    description:
+      "Mid-century modern living room with Benjamin Moore Hale Navy HC-154 walls (LRV 7.1, deep navy), White Dove trim, and Edgecomb Gray adjacent walls. Brass hardware, walnut credenza, cream linen — the most-searched modern navy with two warm neutrals that complete the palette. Cross-brand matches across Sherwin-Williams, Behr, and Valspar at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/best-blue-paint-colors" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 2,
+    name: "Agreeable Gray Open-Plan Kitchen",
+    image: "Agreeable Gray Open-Plan Kitchen.png",
+    prompt:
+      "Vertical 2:3 pin showing an open-plan kitchen-dining room. The walls are painted Agreeable Gray. The upper and lower shaker cabinets are painted Pure White. The island base is painted Iron Ore (the dark contrast against the Pure White cabinets is the focal point). Butcher-block island countertop, brass pendant lights, white oak floors, ceramic vase with eucalyptus. Three color swatches overlay the bottom-left corner: Agreeable Gray (HEX #D1CBC1, RGB 209, 203, 193, LRV 60, Undertone Warm Neutral), Iron Ore (HEX #43484C, RGB 67, 72, 76, LRV 6, Undertone Cool), Pure White (HEX #F3EEE0, RGB 243, 238, 224, LRV 83.7, Undertone Warm) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Agreeable Gray Kitchen Palette — SW 7029 with Iron Ore Accent",
+    description:
+      "Sherwin-Williams Agreeable Gray SW 7029 (LRV 60) is the most-searched warm gray in residential paint. Paired with Iron Ore on the island and Pure White cabinets — a designer-tested whole-house palette that holds up under both warm-bulb evening light and cool-LED daylight. See cross-brand equivalents at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/colors/sherwin-williams/agreeable-gray-7029" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 3,
+    name: "Iron Ore Front Door",
+    image: "Iron Ore Front Door.png",
+    prompt:
+      "Vertical 2:3 pin showing a residential house exterior. The siding around the entry is painted Alabaster. The front door is painted Iron Ore. Brass mailbox mounted next to the door, terracotta planter with native succulents on the porch, exposed white oak porch beam overhead, late-afternoon golden hour light raking across the siding. Two color swatches overlay the bottom-left corner: Iron Ore (HEX #43484C, RGB 67, 72, 76, LRV 6, Undertone Cool), Alabaster (HEX #ECE3D7, RGB 236, 227, 215, LRV 82, Undertone Warm) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Iron Ore Front Door — SW 7069 Soft Black Paint Color",
+    description:
+      "Sherwin-Williams Iron Ore SW 7069 is the off-black favorite for modern farmhouse and craftsman front doors. LRV 6 — deep enough to anchor the exterior without going pure black. Paired with Alabaster siding for the cleanest contrast. See the full PaintColorHQ guide to Iron Ore including 14-brand cross-matches.",
+    link: "https://www.paintcolorhq.com/colors/sherwin-williams/iron-ore-7069" + UTM,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 4,
+    name: "Best Whites Side-by-Side",
+    image: "Best Whites Side-by-Side.png",
+    prompt:
+      "Vertical 2:3 pin showing three vertical wall panels side-by-side under soft north-facing daylight, each panel painted a different white and labeled. Three color swatches overlay the bottom-left corner: Chantilly Lace (HEX #F5F1EB, RGB 245, 241, 235, LRV 92.3, Undertone Neutral), Pure White (HEX #F3EEE0, RGB 243, 238, 224, LRV 83.7, Undertone Warm), White Dove (HEX #EDE6D3, RGB 237, 230, 211, LRV 83, Undertone Warm) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), brand, HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all six fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 92.3, not 923).",
+    title: "Best White Paint Colors Compared — Chantilly Lace vs Pure White vs White Dove",
+    description:
+      "The three most-specified residential whites compared side-by-side: Benjamin Moore Chantilly Lace (LRV 92.3, true white), Sherwin-Williams Pure White (LRV 83.7, warm), Benjamin Moore White Dove (LRV 83, warmest of the three). Choose by undertone — full guide and cross-brand matches at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/best-white-paint-colors-guide" + UTM,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 5,
+    name: "Sage Bathroom",
+    image: "Sage Bathroom.png",
+    prompt:
+      "Vertical 2:3 pin showing a small bathroom. The walls are painted Evergreen Fog. The ceiling, door trim, and crown molding are painted Pure White. The floating vanity cabinet is painted Saybrook Sage (a lighter sage that contrasts gently against the deeper Evergreen Fog walls). White subway tile shower with unlacquered brass shower fixture, round rattan-framed mirror, eucalyptus stems in a stoneware vase on the vanity. Three color swatches overlay the bottom-left corner: Evergreen Fog (HEX #95A18D, RGB 149, 161, 141, LRV 30, Undertone Cool Green), Pure White (HEX #F3EEE0, RGB 243, 238, 224, LRV 83.7, Undertone Warm), Saybrook Sage (HEX #B2BAA4, RGB 178, 186, 164, LRV 46.4, Undertone Cool Green) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Sage Bathroom Palette — Evergreen Fog with White Subway Tile",
+    description:
+      "Sherwin-Williams Evergreen Fog SW 9130 in a small bathroom with white subway tile, unlacquered brass fixtures, and white oak vanity. LRV 30 — deep enough to feel intentional in a windowless room, soft enough to stay calming. Saybrook Sage and Pure White complete the palette. Full sage paint guide at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/best-bathroom-paint-colors" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 6,
+    name: "Naval Kitchen Cabinets",
+    image: "Naval Kitchen Cabinets.png",
+    prompt:
+      "Vertical 2:3 pin showing a transitional kitchen. The lower shaker cabinets are painted Naval. The upper cabinets and main kitchen walls are painted Pure White. Visible through a wide cased opening to the adjacent dining area, the dining-room wall is painted Accessible Beige (warm neutral contrast against the cool Pure White kitchen). Honed white marble countertop with light gray veining, brass cabinet hardware, three brass-shaded pendant lights over the island. Three color swatches overlay the bottom-left corner: Naval (HEX #34405A, RGB 52, 64, 90, LRV 4.5, Undertone Cool Blue), Pure White (HEX #F3EEE0, RGB 243, 238, 224, LRV 83.7, Undertone Warm), Accessible Beige (HEX #D1C4A9, RGB 209, 196, 169, LRV 57.9, Undertone Warm Neutral) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Naval Kitchen Cabinets — SW 6244 Navy with White Marble",
+    description:
+      "Sherwin-Williams Naval SW 6244 (LRV 4.5, deep cool navy) on lower cabinets with Pure White uppers, honed marble counters, and unlacquered brass hardware. The two-tone cabinet trend that's stayed in style for a decade. Accessible Beige as the adjacent dining wall keeps the palette warm. PaintColorHQ has cross-brand matches for Naval across Behr, Benjamin Moore, and PPG.",
+    link: "https://www.paintcolorhq.com/blog/best-sherwin-williams-kitchen-colors" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 7,
+    name: "Pink Hydrangea Nursery",
+    image: "Pink Hydrangea Nursery.png",
+    prompt:
+      "Vertical 2:3 pin showing a gender-neutral nursery. The three main walls are painted Pink Hydrangea. The ceiling, door trim, and window casing are painted Simply White. The accent wall behind the crib is painted Saybrook Sage (sage-green contrast that anchors the pink without competing). Blonde-wood crib placed against the Saybrook Sage accent wall, white rattan rocking chair, ivory wool flatweave rug, brass mobile hanging over the crib, single eucalyptus garland above the crib. Soft morning light from a left-side window. Three color swatches overlay the bottom-left corner: Pink Hydrangea (HEX #FEB6D4, RGB 254, 182, 212, LRV 62, Undertone Warm Pink), Simply White (HEX #F1EDE3, RGB 241, 237, 227, LRV 92.5, Undertone Warm), Saybrook Sage (HEX #B2BAA4, RGB 178, 186, 164, LRV 46.4, Undertone Cool Green) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Pink Hydrangea Nursery — Soft Pink Paint Color Palette",
+    description:
+      "Behr Pink Hydrangea 160A-3 (LRV 62, warm soft pink) in a gender-neutral nursery with blonde wood, white rattan, ivory wool, and brass accents. Sage green accent wall (Saybrook Sage) adds contrast that keeps the pink from reading too sweet. Pinks transition through life stages — perfect for nursery-to-toddler-to-guest-room. Full nursery paint guide at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/best-nursery-paint-colors" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 8,
+    name: "Cinnamon Slate Dining Room",
+    image: "Cinnamon Slate Dining Room.png",
+    prompt:
+      "Vertical 2:3 pin showing a moody dining room. The main dining-room walls are painted Cinnamon Slate. The ceiling, crown molding, baseboard, and door trim are painted Chantilly Lace. Visible through a cased doorway opening to an adjacent powder room, the powder-room wall is painted Hale Navy (the navy reads as a deeper architectural accent through the doorway). Brass linear chandelier over a walnut pedestal dining table, six cream-linen upholstered dining chairs, two brass candlesticks on the table, single arched gold-framed mirror on the focal Cinnamon Slate wall. Evening light, candles lit. Three color swatches overlay the bottom-left corner: Cinnamon Slate (HEX #7B5B4C, RGB 123, 91, 76, LRV 14, Undertone Warm Plum-Brown), Chantilly Lace (HEX #F5F1EB, RGB 245, 241, 235, LRV 92.3, Undertone Neutral), Hale Navy (HEX #3E4450, RGB 62, 68, 80, LRV 7.1, Undertone Cool Blue) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Cinnamon Slate Dining Room — Benjamin Moore 2025 Color of the Year",
+    description:
+      "Benjamin Moore Cinnamon Slate 2113-40 (LRV 14, heathered plum-brown) — the 2025 Color of the Year — in a moody candlelit dining room with walnut, cream linen, and brass. Chantilly Lace on the trim keeps the contrast crisp. Hale Navy as a powder-room accent extends the palette. Full 2025 Color of the Year comparison at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/2025-colors-of-the-year-every-brand-compared" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 9,
+    name: "Hidden Gem Mudroom (Color-Drenched)",
+    image: "Hidden Gem Mudroom (Color-Drenched).png",
+    prompt:
+      "Vertical 2:3 pin showing a small mudroom color-drenched in Hidden Gem — the walls, lower cabinets, open shelving, and ceiling are all painted Hidden Gem (single-color drench creates an enveloping monochrome effect). The exterior door visible at one end of the mudroom is painted White Dove (the warm-white door functions as the single bright contrast against the all-over Hidden Gem drench). Unlacquered brass coat hooks mounted on the wall, three woven baskets on open shelves, a white oak bench with a cream wool throw, terracotta hexagonal floor tile. Two color swatches overlay the bottom-left corner: Hidden Gem (HEX #596D69, RGB 89, 109, 105, LRV 14.1, Undertone Cool Green), White Dove (HEX #EDE6D3, RGB 237, 230, 211, LRV 83, Undertone Warm) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Hidden Gem Mudroom — Behr 2026 Color of the Year, Color-Drenched",
+    description:
+      "Behr Hidden Gem N430-6A (LRV 14.1, smoky jade green) — the 2026 Color of the Year — color-drenched across walls, cabinets, and ceiling in a small mudroom. The green undertone neutralizes the harsh cast of cool LED bulbs in a way no navy can. Brass hooks, terracotta tile, white oak bench complete the palette. Full 2026 Color of the Year guide at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/blog/2026-colors-of-the-year-every-brand-compared" + UTM,
+    board: "Color Palettes",
+  },
+  {
+    id: 10,
+    name: "Sea Salt Cottage Kitchen",
+    image: "Sea Salt Cottage Kitchen.png",
+    prompt:
+      "Vertical 2:3 pin showing a cottage-style kitchen. The walls are painted Sea Salt. The upper shaker cabinets are painted Pure White. The island base is painted Iron Ore (deep cool contrast that anchors the soft Sea Salt walls and Pure White uppers). White quartz countertop with subtle gray veining, brass cup pulls and knobs on the cabinetry, two glass-shaded brass pendants hanging over the Iron Ore island, an open shelf with cream stoneware. Bright morning light. Three color swatches overlay the bottom-left corner: Sea Salt (HEX #CBD1C2, RGB 203, 209, 194, LRV 63.3, Undertone Cool Blue-Green), Pure White (HEX #F3EEE0, RGB 243, 238, 224, LRV 83.7, Undertone Warm), Iron Ore (HEX #43484C, RGB 67, 72, 76, LRV 6, Undertone Cool) — render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. Use clean sans-serif text (Inter or Helvetica), no decorative styling. Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. Preserve decimal points in LRV values (e.g. 7.1, not 71).",
+    title: "Sea Salt Kitchen Palette — SW 6204 with Pure White Cabinets",
+    description:
+      "Sherwin-Williams Sea Salt SW 6204 (LRV 63.3) is the rare blue-green that reads as either pale blue or pale green depending on the light — perfect for a cottage kitchen with white shaker cabinets and brass cup pulls. Iron Ore on the island base adds anchoring depth. One of SW's top-selling colors for a decade. Cross-brand matches at PaintColorHQ.",
+    link: "https://www.paintcolorhq.com/colors/sherwin-williams/sea-salt-6204" + UTM,
+    board: "Color Palettes",
+  },
+];


### PR DESCRIPTION
## What

A reusable Pinterest pipeline so future pin batches are near-zero-effort. Used end-to-end this session to publish the 10-pin **may26-pin-batch** cohort live.

## Scripts (`scripts/`)

| File | Purpose |
|---|---|
| `pinterest/batch-may26.ts` | Source of truth — 10 PinSpecs (prompt / title / description / UTM link / board) + verified board IDs + `IMAGE_DIR` |
| `pinterest-generate.ts` | Nano Banana (`gemini-3-pro-image`) → 2:3 images, fresh API context per call (eliminates web-app context contamination). `--only` / `--force` for cheap regen-on-QA-fail |
| `pinterest-auth.ts` | One-time OAuth (localhost:8732) → mints a `pins:write` + `boards:write` token into `.env.local` |
| `pinterest-publish.ts` | `POST /v5/pins` via `image_base64`, content-type sniffed from magic bytes, auto-refresh on 401, idempotent publish log to prevent double-posts. `--dry-run` / `--only` |

## Safety

- All credentials stay in untracked `.env.local`
- Runtime publish log (`scripts/pinterest/published-*.json`) is gitignored
- Standalone tsx scripts — not imported by the app, no impact on the Next.js build/deploy

## Verified

- `gemini-3-pro-image` produced correct swatches first-try (text, HEX, LRV)
- OAuth token carries `boards:read/write`, `pins:read/write`, `user_accounts:read`
- Dry-run validated all 10 pins; all 10 published live and confirmed via the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)