### PR TITLE
fix(api/pin): require valid hex, drop misleading default swatch

### DIFF
--- a/src/app/api/pin/route.tsx
+++ b/src/app/api/pin/route.tsx
@@ -17,7 +17,20 @@ export const runtime = "edge";
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
-  const hex = searchParams.get("hex") || "#4A90D9";
+
+  // Require a valid #RRGGBB hex — do NOT fall back to a default color.
+  // A param-less hit used to render a believable blue "#4A90D9 / Paint Color"
+  // swatch, which Pinterest then froze on its CDN as a wrong-but-plausible pin
+  // (the Adams Gold fossil). Failing loudly means a bad request produces no
+  // image instead of a misleading one that can never be un-cached.
+  const normalizedHex = searchParams.get("hex")?.trim().replace(/^#/, "");
+  if (!normalizedHex || !/^[0-9a-fA-F]{6}$/.test(normalizedHex)) {
+    return new Response("Missing or invalid 'hex' parameter (expected #RRGGBB)", {
+      status: 400,
+    });
+  }
+  const hex = `#${normalizedHex}`;
+
   const name = searchParams.get("name") || "Paint Color";
   const brand = searchParams.get("brand") || "";
   const code = searchParams.get("code") || "";


### PR DESCRIPTION
## Problem

`/api/pin` (the Pinterest OG-image route) fell back to **`hex = "#4A90D9"` (blue)** and **`name = "Paint Color"`** when params were missing. A param-less or malformed hit rendered a *believable-but-wrong* blue swatch — and Pinterest **freezes pin images on its CDN at save-time**, so any such image becomes a permanent wrong pin.

This is the confirmed root cause of the long-standing Adams Gold anomaly: a third-party pin showing a **blue swatch titled "Paint color"** while linking to the correct gold Adams Gold page (image and link are captured independently).

## Fix

- Require a valid `#RRGGBB` hex; return **400** otherwise (no image beats a misleading one that can never be un-cached)
- Normalize a missing leading `#`
- The color detail page always supplies `hex`, so **no real pin path changes**

## Verified locally (dev server)

| Request | Result |
|---|---|
| `/api/pin` (no hex) | **400** ✅ |
| `?hex=%23dbcb9d&name=Adams Gold…` | 200 `image/png` ✅ |
| `?hex=blue` (garbage) | **400** ✅ |
| `?hex=3E4450` (no `#`) | 200 `image/png` ✅ |

## SEO gate note

This only changes error handling on a non-indexed image route — no page content, meta, links, or schema are touched — so the content/meta SEO gate doesn't apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)