### PR TITLE
feat(pinterest): unattended drip-publish schedule (stock→drip)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ scripts/drift/*.db
 scripts/drift/*.db-shm
 scripts/drift/*.db-wal
 
-# Pinterest runtime publish state (pin IDs, not secrets, but runtime-only)
-scripts/pinterest/published-*.json
+# Pinterest runtime state (pin IDs + drip log; not secrets, but runtime-only)
+scripts/pinterest/published*.json
+scripts/pinterest/drip.log

--- a/docs/superpowers/plans/2026-05-30-pinterest-drip-schedule.md
+++ b/docs/superpowers/plans/2026-05-30-pinterest-drip-schedule.md
@@ -1,0 +1,619 @@
+# Pinterest Drip Schedule Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish curated, pre-approved Pinterest pins on an unattended 2×/day schedule from the user's always-on Mac, selecting each pin by a variety rotation so the feed reads as human-curated.
+
+**Architecture:** Generation + QA stay Claude-in-the-loop (unchanged). This plan builds only the *drip* half: a pure, tested selection layer (`queue.ts`), a `--drip` mode on the existing publisher, and a `launchd` job that runs it. State lives in a gitignored global `published.json`; secrets stay in `.env.local`.
+
+**Tech Stack:** TypeScript run via `tsx`, Node built-in test runner (`node --import tsx --test`), Pinterest API v5 (already wrapped in `scripts/pinterest-publish.ts`), macOS `launchd`.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md`
+
+---
+
+## File Structure
+
+- `scripts/pinterest/batch-may26.ts` (MODIFY) — add `key`/`theme`/`format` to `PinSpec` + tag all 10 pins.
+- `scripts/pinterest/queue.ts` (CREATE) — aggregate batches into `QUEUE`; pure selection functions (`unpublished`, `recentlyPublished`, `collisionScore`, `pickNext`, `selectForDrip`).
+- `scripts/pinterest/queue.test.ts` (CREATE) — unit tests for the selection layer.
+- `scripts/pinterest/published.json` (MIGRATE, gitignored) — global log keyed by `PinSpec.key`.
+- `scripts/pinterest-publish.ts` (MODIFY) — operate on `QUEUE` + global log; add `--drip=N` (variety rotation) and empty-queue notification; `--only` now keys.
+- `scripts/pinterest/drip.sh` (CREATE) — launchd wrapper: cd repo, run `--drip`, log.
+- `scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template` (CREATE) — launchd schedule template.
+- `scripts/pinterest/install-drip-schedule.sh` (CREATE) — render + load/unload the agent.
+- `.gitignore` (MODIFY) — ignore `published*.json` + `drip.log`.
+- `package.json` (MODIFY) — add `test:pinterest` script.
+
+---
+
+## Task 1: Extend PinSpec with key/theme/format and tag the may26 batch
+
+**Files:**
+- Modify: `scripts/pinterest/batch-may26.ts`
+
+- [ ] **Step 1: Add the three fields to the `PinSpec` interface**
+
+In `scripts/pinterest/batch-may26.ts`, add to the `interface PinSpec` (after `id`):
+
+```ts
+  /** Stable, globally-unique key across all batches (e.g. "may26-01"). */
+  key: string;
+  /** Variety axis — color/subject (e.g. "navy", "white", "sage"). */
+  theme: string;
+  /** Variety axis — scene/room type (e.g. "living-room", "kitchen", "exterior"). */
+  format: string;
+```
+
+- [ ] **Step 2: Tag all 10 pins**
+
+Add `key`, `theme`, `format` to each `BATCH` entry, using these exact values:
+
+```
+id 1  key "may26-01" theme "navy"        format "living-room"
+id 2  key "may26-02" theme "warm-gray"   format "kitchen"
+id 3  key "may26-03" theme "soft-black"  format "exterior"
+id 4  key "may26-04" theme "white"       format "comparison"
+id 5  key "may26-05" theme "sage"        format "bathroom"
+id 6  key "may26-06" theme "navy"        format "kitchen"
+id 7  key "may26-07" theme "pink"        format "nursery"
+id 8  key "may26-08" theme "plum-brown"  format "dining-room"
+id 9  key "may26-09" theme "green"       format "color-drench"
+id 10 key "may26-10" theme "blue-green"  format "kitchen"
+```
+
+Example for entry 1 (place the fields right after `id: 1,`):
+
+```ts
+  {
+    id: 1,
+    key: "may26-01",
+    theme: "navy",
+    format: "living-room",
+    name: "Hale Navy Living Room",
+    // ...rest unchanged
+```
+
+- [ ] **Step 3: Verify it still type-checks and keys are unique**
+
+Run:
+```bash
+npx tsx -e 'import { BATCH } from "./scripts/pinterest/batch-may26.ts"; const k=BATCH.map(p=>p.key); console.log("count",BATCH.length,"unique",new Set(k).size); console.log(BATCH.every(p=>p.theme&&p.format)?"all tagged":"MISSING TAG");'
+```
+Expected: `count 10 unique 10` and `all tagged`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/pinterest/batch-may26.ts
+git commit -m "feat(pinterest): add key/theme/format variety tags to PinSpec + may26 batch"
+```
+
+---
+
+## Task 2: Queue aggregation + variety selection (TDD)
+
+**Files:**
+- Create: `scripts/pinterest/queue.ts`
+- Test: `scripts/pinterest/queue.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the test script to package.json**
+
+In `package.json` `"scripts"`, add:
+```json
+    "test:pinterest": "node --import tsx --test scripts/pinterest/queue.test.ts",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `scripts/pinterest/queue.test.ts`:
+
+```ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  unpublished,
+  collisionScore,
+  pickNext,
+  selectForDrip,
+  type PinSpec,
+  type PublishedLog,
+} from "./queue.ts";
+
+// Minimal PinSpec stub — only the fields the selection layer reads.
+function mk(key: string, theme: string, format: string, board: PinSpec["board"]): PinSpec {
+  return { key, theme, format, board } as unknown as PinSpec;
+}
+
+const Q: PinSpec[] = [
+  mk("a", "navy", "living-room", "Color Palettes"),
+  mk("b", "navy", "kitchen", "Color Palettes"),
+  mk("c", "sage", "bathroom", "Color Palettes"),
+  mk("d", "white", "comparison", "Paint Color Guides"),
+];
+
+test("unpublished filters out keys present in the log", () => {
+  const log: PublishedLog = { a: { pinId: "1", publishedAt: "2026-05-30T00:00:00Z" } };
+  assert.deepEqual(unpublished(Q, log).map((p) => p.key), ["b", "c", "d"]);
+});
+
+test("collisionScore counts shared theme/format/board", () => {
+  const recent = [mk("a", "navy", "living-room", "Color Palettes")];
+  assert.equal(collisionScore(mk("x", "navy", "kitchen", "Color Palettes"), recent), 2); // theme+board
+  assert.equal(collisionScore(mk("y", "white", "comparison", "Paint Color Guides"), recent), 0);
+});
+
+test("pickNext prefers lowest collision, tie-breaks by queue order", () => {
+  const recent = [mk("a", "navy", "living-room", "Color Palettes")];
+  // b collides (navy+board=2), c collides (board=1), d collides (0) -> pick d
+  assert.equal(pickNext([Q[1], Q[2], Q[3]], recent)!.key, "d");
+  // with no recent, all score 0 -> first in queue order
+  assert.equal(pickNext([Q[1], Q[2], Q[3]], [])!.key, "b");
+});
+
+test("selectForDrip returns [] when everything is published", () => {
+  const log: PublishedLog = Object.fromEntries(
+    Q.map((p) => [p.key, { pinId: "x", publishedAt: "2026-05-30T00:00:00Z" }]),
+  );
+  assert.deepEqual(selectForDrip(Q, log, 2), []);
+});
+
+test("selectForDrip(N=2) does not pick two of the same theme back-to-back", () => {
+  // Fresh log; a and b are both navy. Expect first pick a (queue order),
+  // second pick should avoid navy -> c (sage), not b.
+  const picks = selectForDrip(Q, {}, 2).map((p) => p.key);
+  assert.equal(picks[0], "a");
+  assert.notEqual(picks[1], "b");
+  assert.equal(picks[1], "c");
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm run test:pinterest`
+Expected: FAIL — `Cannot find module './queue.ts'` (file not created yet).
+
+- [ ] **Step 4: Implement `queue.ts`**
+
+Create `scripts/pinterest/queue.ts`:
+
+```ts
+// Aggregated, approved Pinterest pin queue + variety-rotation selection.
+// Pure functions only — no I/O — so the drip logic is unit-testable.
+
+import { BATCH as MAY26 } from "./batch-may26.ts";
+export { BOARD_IDS, IMAGE_DIR } from "./batch-may26.ts";
+export type { PinSpec, BoardName } from "./batch-may26.ts";
+import type { PinSpec } from "./batch-may26.ts";
+
+/** All approved batches, concatenated in intended publish order. */
+export const QUEUE: PinSpec[] = [...MAY26];
+
+export type PublishedLog = Record<string, { pinId: string; publishedAt: string }>;
+
+export const LOOKBACK = 3;
+
+/** Queue entries whose key is not yet in the published log, in queue order. */
+export function unpublished(queue: PinSpec[], published: PublishedLog): PinSpec[] {
+  return queue.filter((p) => !(p.key in published));
+}
+
+/** The most recently published specs (newest first), capped to `lookback`. */
+export function recentlyPublished(
+  queue: PinSpec[],
+  published: PublishedLog,
+  lookback: number,
+): PinSpec[] {
+  const byKey = new Map(queue.map((p) => [p.key, p]));
+  return Object.entries(published)
+    .filter(([key]) => byKey.has(key))
+    .sort((a, b) => (a[1].publishedAt < b[1].publishedAt ? 1 : -1)) // newest first
+    .slice(0, lookback)
+    .map(([key]) => byKey.get(key)!);
+}
+
+/** How many of {theme, format, board} a candidate shares with the recent window. */
+export function collisionScore(candidate: PinSpec, recent: PinSpec[]): number {
+  const themes = new Set(recent.map((r) => r.theme));
+  const formats = new Set(recent.map((r) => r.format));
+  const boards = new Set(recent.map((r) => r.board));
+  return (
+    (themes.has(candidate.theme) ? 1 : 0) +
+    (formats.has(candidate.format) ? 1 : 0) +
+    (boards.has(candidate.board) ? 1 : 0)
+  );
+}
+
+/** Lowest-collision candidate; ties keep the earliest (queue order). */
+export function pickNext(candidates: PinSpec[], recent: PinSpec[]): PinSpec | null {
+  if (candidates.length === 0) return null;
+  let best = candidates[0];
+  let bestScore = collisionScore(best, recent);
+  for (const c of candidates.slice(1)) {
+    const s = collisionScore(c, recent);
+    if (s < bestScore) {
+      best = c;
+      bestScore = s;
+    }
+  }
+  return best;
+}
+
+/** Pick `count` unpublished pins via the variety rotation. */
+export function selectForDrip(
+  queue: PinSpec[],
+  published: PublishedLog,
+  count: number,
+  lookback = LOOKBACK,
+): PinSpec[] {
+  const chosen: PinSpec[] = [];
+  const prior = recentlyPublished(queue, published, lookback); // newest first
+  let pool = unpublished(queue, published);
+  for (let i = 0; i < count; i++) {
+    // recent window = this run's picks (newest first) + prior, capped to lookback
+    const window = [...chosen].reverse().concat(prior).slice(0, lookback);
+    const next = pickNext(pool, window);
+    if (!next) break;
+    chosen.push(next);
+    pool = pool.filter((p) => p.key !== next.key);
+  }
+  return chosen;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm run test:pinterest`
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/pinterest/queue.ts scripts/pinterest/queue.test.ts package.json
+git commit -m "feat(pinterest): queue aggregation + tested variety-rotation selection"
+```
+
+---
+
+## Task 3: Migrate the published log to a global keyed file
+
+**Files:**
+- Create: `scripts/pinterest/published.json` (gitignored — generated, not committed)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Update .gitignore**
+
+The current ignore pattern is `scripts/pinterest/published-*.json`, which does NOT match `published.json`. Replace that line (and add the log) so both are ignored:
+
+```
+# Pinterest runtime state (pin IDs + drip log; not secrets, but runtime-only)
+scripts/pinterest/published*.json
+scripts/pinterest/drip.log
+```
+
+- [ ] **Step 2: Migrate the existing log to keyed form**
+
+Run (maps id `"1".."10"` → `"may26-01".."may26-10"`, preserving pinId/publishedAt):
+```bash
+cd /Users/philipcameron/Documents/GitHub/paintcolorhq
+npx tsx -e '
+import * as fs from "fs";
+const dir = "scripts/pinterest";
+const old = JSON.parse(fs.readFileSync(`${dir}/published-may26.json`, "utf8"));
+const out: Record<string, unknown> = {};
+for (const [id, v] of Object.entries(old)) out[`may26-${String(id).padStart(2, "0")}`] = v;
+fs.writeFileSync(`${dir}/published.json`, JSON.stringify(out, null, 2) + "\n");
+console.log("migrated keys:", Object.keys(out).join(", "));
+'
+```
+Expected: `migrated keys: may26-01, may26-02, ... may26-10`.
+
+- [ ] **Step 3: Verify the queue now reports zero unpublished**
+
+Run:
+```bash
+npx tsx -e '
+import { QUEUE, unpublished, type PublishedLog } from "./scripts/pinterest/queue.ts";
+import * as fs from "fs";
+const log: PublishedLog = JSON.parse(fs.readFileSync("scripts/pinterest/published.json","utf8"));
+console.log("unpublished:", unpublished(QUEUE, log).length);
+'
+```
+Expected: `unpublished: 0` (the may26 batch is fully live; the drip correctly starts empty until a new batch is stocked).
+
+- [ ] **Step 4: Confirm both state files are gitignored**
+
+Run: `git check-ignore scripts/pinterest/published.json scripts/pinterest/published-may26.json`
+Expected: both paths echoed back.
+
+- [ ] **Step 5: Commit the .gitignore change**
+
+```bash
+git add .gitignore
+git commit -m "chore(pinterest): gitignore global published.json + drip.log"
+```
+
+---
+
+## Task 4: Add `--drip` mode to the publisher (operate on the global queue)
+
+**Files:**
+- Modify: `scripts/pinterest-publish.ts`
+
+- [ ] **Step 1: Repoint imports and the log path**
+
+Replace the batch import line:
+```ts
+import { BATCH, BOARD_IDS, IMAGE_DIR, type PinSpec } from "./pinterest/batch-may26.ts";
+```
+with:
+```ts
+import {
+  QUEUE,
+  BOARD_IDS,
+  IMAGE_DIR,
+  selectForDrip,
+  type PinSpec,
+  type PublishedLog,
+} from "./pinterest/queue.ts";
+```
+
+Change the log path constant:
+```ts
+const LOG_PATH = path.resolve(__dirname, "pinterest/published.json");
+```
+
+- [ ] **Step 2: Replace the CLI arg parsing block**
+
+Replace the `--only` / `--dry-run` parsing with `--drip` support (keys, not ids):
+
+```ts
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const dripArg = args.find((a) => a.startsWith("--drip="));
+const DRIP = dripArg ? Math.max(1, parseInt(dripArg.replace("--drip=", ""), 10) || 1) : null;
+const onlyArg = args.find((a) => a.startsWith("--only="));
+const onlyKeys = onlyArg ? new Set(onlyArg.replace("--only=", "").split(",")) : null;
+```
+
+- [ ] **Step 3: Type the log + use keys in the publish/skip logic**
+
+Change `loadLog`'s return type to `PublishedLog`, and in `publishPin` key everything off `pin.key` instead of `pin.id`:
+
+```ts
+function loadLog(): PublishedLog {
+  try { return JSON.parse(fs.readFileSync(LOG_PATH, "utf8")); } catch { return {}; }
+}
+```
+In `publishPin`, replace `log[pin.id]` lookups/writes with `log[pin.key]`, and the label with `` `#${pin.key} ${pin.name}` ``.
+
+- [ ] **Step 4: Add the empty-queue notification helper**
+
+Add near the top (after imports):
+```ts
+import { execFile } from "child_process";
+
+function notify(message: string) {
+  // macOS local notification — best-effort, never throws.
+  execFile("osascript", ["-e", `display notification "${message.replace(/"/g, "'")}" with title "PaintColorHQ"`], () => {});
+}
+```
+
+- [ ] **Step 5: Rewrite `main()` to support drip selection**
+
+```ts
+async function main() {
+  const log = loadLog();
+  let targets: PinSpec[];
+  if (DRIP) {
+    targets = selectForDrip(QUEUE, log, DRIP);
+    if (targets.length === 0) {
+      console.log("Drip: queue empty — nothing unpublished to post.");
+      if (!DRY_RUN) notify("Pinterest queue empty — stock more with Claude.");
+      return;
+    }
+  } else {
+    targets = QUEUE.filter((p) => (onlyKeys ? onlyKeys.has(p.key) : true));
+  }
+  console.log(
+    `${DRY_RUN ? "DRY RUN — " : ""}Publishing ${targets.length} pin(s)` +
+      `${DRIP ? ` (drip, variety rotation)` : onlyKeys ? ` (--only=${[...onlyKeys].join(",")})` : ""}\n`,
+  );
+  for (const pin of targets) {
+    try {
+      await publishPin(pin, log);
+    } catch (e) {
+      console.error(`❌ ${pin.key} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+    }
+    if (!DRY_RUN) await new Promise((r) => setTimeout(r, 2500));
+  }
+  console.log("\nDone.");
+}
+```
+
+- [ ] **Step 6: Dry-run verify drip selection (queue currently empty)**
+
+Run: `npx tsx scripts/pinterest-publish.ts --dry-run --drip=2`
+Expected: `Drip: queue empty — nothing unpublished to post.` (correct — may26 is all published; no notification fires under `--dry-run`).
+
+- [ ] **Step 7: Verify selection works against a stocked queue (temporary fixture)**
+
+Temporarily remove one key from the log to simulate an unpublished pin, dry-run, then restore:
+```bash
+cp scripts/pinterest/published.json /tmp/pub.bak
+npx tsx -e 'import * as fs from "fs";const p="scripts/pinterest/published.json";const d=JSON.parse(fs.readFileSync(p,"utf8"));delete d["may26-09"];fs.writeFileSync(p,JSON.stringify(d,null,2));'
+npx tsx scripts/pinterest-publish.ts --dry-run --drip=1
+cp /tmp/pub.bak scripts/pinterest/published.json
+```
+Expected: dry-run lists `#may26-09 Hidden Gem Mudroom` as the selected pin; log restored afterward.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/pinterest-publish.ts
+git commit -m "feat(pinterest): --drip variety mode on the global queue + empty-queue notify"
+```
+
+---
+
+## Task 5: launchd wrapper script
+
+**Files:**
+- Create: `scripts/pinterest/drip.sh`
+
+- [ ] **Step 1: Write the wrapper**
+
+Create `scripts/pinterest/drip.sh`:
+```bash
+#!/usr/bin/env bash
+# launchd entry point for the Pinterest drip. Resolves the repo root from its
+# own location, then publishes one pin. Logs everything to drip.log.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+COUNT="${1:-1}"
+echo "=== drip run $(date -u +%Y-%m-%dT%H:%M:%SZ) (count=$COUNT) ===" >> "$REPO/scripts/pinterest/drip.log"
+npx tsx scripts/pinterest-publish.ts --drip="$COUNT" >> "$REPO/scripts/pinterest/drip.log" 2>&1
+```
+
+- [ ] **Step 2: Make it executable and smoke-test it**
+
+Run:
+```bash
+chmod +x scripts/pinterest/drip.sh
+./scripts/pinterest/drip.sh 1
+tail -5 scripts/pinterest/drip.log
+```
+Expected: log shows the run header + `Drip: queue empty — nothing unpublished to post.` (queue is empty, so no live post — safe smoke test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/pinterest/drip.sh
+git commit -m "feat(pinterest): launchd wrapper script for the drip"
+```
+
+---
+
+## Task 6: launchd plist template + installer
+
+**Files:**
+- Create: `scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template`
+- Create: `scripts/pinterest/install-drip-schedule.sh`
+
+- [ ] **Step 1: Write the plist template**
+
+Create `scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template`:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>__LABEL__</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__DRIPSH__</string>
+    <string>1</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>__NODE_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+  </array>
+  <key>StandardErrorPath</key><string>__REPO__/scripts/pinterest/drip.log</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Write the installer**
+
+Create `scripts/pinterest/install-drip-schedule.sh`:
+```bash
+#!/usr/bin/env bash
+# Render the launchd plist with this machine's paths and (un)load it.
+# Usage: ./install-drip-schedule.sh           # install
+#        ./install-drip-schedule.sh uninstall # remove
+set -euo pipefail
+LABEL="com.paintcolorhq.pinterest-drip"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if [[ "${1:-}" == "uninstall" ]]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "Uninstalled $LABEL."
+  exit 0
+fi
+
+DRIPSH="$REPO/scripts/pinterest/drip.sh"
+NODE_DIR="$(dirname "$(command -v node)")"
+chmod +x "$DRIPSH"
+mkdir -p "$HOME/Library/LaunchAgents"
+sed -e "s|__LABEL__|$LABEL|g" \
+    -e "s|__DRIPSH__|$DRIPSH|g" \
+    -e "s|__NODE_DIR__|$NODE_DIR|g" \
+    -e "s|__REPO__|$REPO|g" \
+    "$REPO/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template" > "$PLIST"
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+echo "Installed $LABEL — drips 1 pin at 13:00 and 21:00 UTC (9am/5pm EDT)."
+echo "Logs: $REPO/scripts/pinterest/drip.log"
+echo "Uninstall: $DRIPSH ... -> ./scripts/pinterest/install-drip-schedule.sh uninstall"
+```
+
+- [ ] **Step 3: Make installer executable and commit (do NOT load yet — load is a verification step)**
+
+```bash
+chmod +x scripts/pinterest/install-drip-schedule.sh
+git add scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template scripts/pinterest/install-drip-schedule.sh
+git commit -m "feat(pinterest): launchd plist template + install/uninstall script"
+```
+
+---
+
+## Task 7: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Install the launchd agent**
+
+Run: `./scripts/pinterest/install-drip-schedule.sh`
+Expected: "Installed com.paintcolorhq.pinterest-drip …".
+
+- [ ] **Step 2: Confirm launchd registered it**
+
+Run: `launchctl list | grep pinterest-drip`
+Expected: a line containing `com.paintcolorhq.pinterest-drip`.
+
+- [ ] **Step 3: Fire the scheduled job once via launchd (proves PATH/wrapper work)**
+
+Run:
+```bash
+launchctl start com.paintcolorhq.pinterest-drip
+sleep 5
+tail -8 scripts/pinterest/drip.log
+```
+Expected: a fresh run header + `Drip: queue empty …` (queue empty = no live post; this proves launchd→wrapper→tsx→node all resolve correctly). Because the queue is empty, the empty-queue macOS notification should also appear.
+
+- [ ] **Step 4: (Optional) live-publish rehearsal**
+
+Only when a NEW approved batch has been stocked: `npx tsx scripts/pinterest-publish.ts --drip=1` should publish exactly one pin and append its key to `published.json`. Re-running should pick a *different* theme/format. Skip while the queue is empty.
+
+- [ ] **Step 5: Final commit (docs/notes only, if any)**
+
+No code change expected here; if verification surfaced a fix, commit it with a descriptive message.
+
+---
+
+## Notes / caveats (from spec)
+
+- **DST:** plist fires at fixed UTC (13:00/21:00). During EST (winter) the local times shift to 8am/4pm. Acceptable; pin timing is not precision-critical.
+- **Sleep:** launchd runs missed `StartCalendarInterval` jobs at next wake.
+- **Token:** `pinterest-publish.ts` auto-refreshes on 401 and writes back to `.env.local`; the launchd job runs as the user, so refresh persists. If refresh fails, the run logs the error to `drip.log`.
+- **Stocking:** the queue stays empty until a new curated batch is added to `queue.ts`. That is the Claude-in-the-loop generate→QA→approve step, out of scope for this plan.

--- a/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
+++ b/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
@@ -1,0 +1,151 @@
+# Pinterest Drip Schedule — Design
+
+**Date:** 2026-05-30
+**Status:** Approved (design), pending implementation plan
+**Scope:** Curated Pinterest pin publishing on an unattended local schedule.
+
+## Goal
+
+Publish curated, Claude-verified Nano Banana pins to Pinterest on a steady
+cadence **without a Claude Code window open and without the user present** —
+while keeping the human/Claude quality gate on every pin.
+
+## Core principle: split the pipeline where judgment is needed
+
+> **Generation + verification needs Claude. Publishing does not.**
+
+- **STOCK** (periodic, local, *with Claude*): generate Nano Banana room-scene
+  pins, Claude reads and QAs every swatch against spec, user approves. Output:
+  finished image files + an approved queue entry. This is unchanged from the
+  workflow used on 2026-05-30 for the may26 batch.
+- **DRIP** (continuous, local, *no Claude*): a scheduled job publishes the next
+  N already-approved, unpublished pins on a cadence. Pure code — no judgment, no
+  window. Runs on the user's always-on Mac via `launchd`.
+
+The user stocks the shelf with Claude occasionally; the schedule empties it
+automatically.
+
+## Constraints
+
+- Runs on the user's Mac, which is on ~24/7 but often unattended.
+- Secrets (`GEMINI_API_KEY`, Pinterest OAuth tokens) stay in untracked
+  `.env.local` — never committed, never sent to a cloud env.
+- Pin images are local files in `~/Desktop/Pinterest pins/`.
+- Nothing publishes that Claude + the user have not already reviewed.
+
+## Out of scope (explicitly)
+
+- **Blog post schedule** — separate subsystem, separate future spec. Same
+  stock→drip shape will apply (draft + Claude reads/QAs + approve → scheduled
+  publish), but blog "publish" is a git commit/deploy, so it needs its own design.
+- **The programmatic Vercel cron** (`/api/cron/pinterest-seed`) — stays OFF.
+  Curated room-scenes are the brand's edge; plain `/api/pin` swatch pins would
+  dilute the boards. Left intact in the codebase, simply not scheduled. May be
+  revisited later if raw volume is wanted.
+- **Auto-generation without Claude QA** — rejected. The whole value is the
+  verification step, which needs a vision-capable agent.
+
+## Architecture
+
+```
+STOCK (with Claude, periodic)              DRIP (launchd, 2×/day, unattended)
+─────────────────────────────             ──────────────────────────────────
+generate → Claude QA → approve            launchd timer (9am + 5pm ET)
+        │                                          │
+        ▼                                          ▼
+  image file in IMAGE_DIR              drip.sh  → npx tsx pinterest-publish.ts --drip=1
+  + queue entry (PinSpec)                        │
+        │                                        ├─ load QUEUE (all approved batches)
+        ▼                                        ├─ skip keys in published.json
+   scripts/pinterest/queue.ts                    ├─ publish next 1 unpublished → Pinterest API
+                                                 ├─ append to published.json
+                                                 └─ if queue empty → notify user "stock more"
+```
+
+### Components
+
+**1. Approved queue — `scripts/pinterest/queue.ts`**
+- Aggregates every approved batch array (starting with `batch-may26.ts`) into a
+  single ordered `QUEUE: PinSpec[]` in intended publish order.
+- `PinSpec` gains a stable, globally-unique `key: string` (e.g. `"may26-01"`),
+  used for the published-state lookup. (Today the may26 entries are keyed
+  `may26-01`…`may26-10`.)
+- New batches are added as new files and concatenated here. The queue file is
+  the single source of "what is approved to publish."
+
+**2. Published-state log — `scripts/pinterest/published.json`**
+- Global, keyed by `PinSpec.key`: `{ [key]: { pinId, publishedAt } }`.
+- Migrated from the existing `published-may26.json` (all 10 may26 keys marked
+  published, so the drip starts with nothing unpublished — correct, since the
+  may26 batch is already live).
+- Gitignored (runtime state; pin IDs, not secrets).
+
+**3. Drip publisher — extend `scripts/pinterest-publish.ts`**
+- New mode `--drip=N`: select the first N entries in `QUEUE` whose `key` is not
+  in `published.json`, publish them, append results, exit. Reuses the existing
+  publish path (base64 upload, content-type sniff, 401→refresh, board mapping).
+- Existing `--only` / `--dry-run` retained for manual use and stock-time testing.
+- If 0 unpublished entries remain, publish nothing and emit the empty-queue
+  signal (component 5).
+
+**4. Schedule — `launchd` + wrapper**
+- `scripts/pinterest/drip.sh`: `cd` to the repo, run
+  `npx tsx scripts/pinterest-publish.ts --drip=1`, append stdout/stderr to
+  `scripts/pinterest/drip.log`. Wrapper isolates PATH/node-resolution (nvm-safe
+  by resolving an absolute node) so the launchd context Just Works.
+- `scripts/pinterest/com.paintcolorhq.pinterest-drip.plist` (template): a
+  `StartCalendarInterval` agent firing at **13:00 and 21:00 UTC** (9am + 5pm ET
+  during EDT) → `--drip=1` twice/day = 2 pins/day. launchd runs missed
+  invocations on wake after sleep.
+  - Note: the plist uses UTC; EDT↔EST means the local clock time shifts by an
+    hour across DST. Acceptable (pin timing is not precision-critical); documented.
+- `scripts/pinterest/install-drip-schedule.sh`: renders the plist with the real
+  repo path + username into `~/Library/LaunchAgents/`, then `launchctl load`s it.
+  A matching `uninstall` path (`launchctl unload` + remove) for teardown.
+  The generated plist lives in `~/Library/LaunchAgents/` (outside the repo); the
+  committed artifact is the template + installer.
+
+**5. Empty-queue signal**
+- When `--drip` finds nothing unpublished, fire a macOS notification via
+  `osascript -e 'display notification "Pinterest queue empty — stock more with Claude" with title "PaintColorHQ"'`
+  and log it. Local, no email dependency. (Optional future: Gmail draft.)
+
+## Data flow (one drip run)
+
+1. launchd fires `drip.sh` at the scheduled time.
+2. Wrapper runs `pinterest-publish.ts --drip=1`.
+3. Script loads `QUEUE` + `published.json`, computes unpublished, takes the first 1.
+4. Reads the local image, base64-encodes, `POST /v5/pins` (401→refresh→retry).
+5. Appends `{key: {pinId, publishedAt}}` to `published.json`.
+6. If nothing was unpublished, fires the empty-queue notification instead.
+
+## Token handling
+
+- `pinterest-publish.ts` already auto-refreshes on 401 and writes the new
+  `PINTEREST_ACCESS_TOKEN` / `PINTEREST_REFRESH_TOKEN` back to `.env.local`. The
+  launchd job runs as the user and can write `.env.local`, so refresh persists
+  across runs. Pinterest refresh tokens are long-lived (~1 year); if refresh ever
+  fails, the empty-queue-style notification surfaces the error and the user
+  re-runs `pinterest-auth.ts`.
+
+## Error handling
+
+- Per-pin failures are caught and logged; the run continues / exits without
+  corrupting `published.json` (only successful publishes are recorded).
+- Missing image file → logged error, pin skipped, not marked published (so it
+  retries next run).
+- Token refresh failure → logged, surfaced via notification; no crash loop.
+- `drip.log` (gitignored) is the audit trail.
+
+## Verification / testing
+
+- `--dry-run --drip=1` to confirm selection logic without posting.
+- Manual `--drip=1` once to confirm a real publish + `published.json` append.
+- `launchctl start` the agent once to confirm the scheduled path + wrapper PATH.
+- Confirm empty-queue notification fires when the queue is exhausted.
+
+## Open follow-ups (not blocking)
+
+- Blog drip schedule (separate spec).
+- Optional Gmail-draft delivery of the empty-queue / error signals.
+- DST handling if precise local times ever matter (currently fixed UTC).

--- a/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
+++ b/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
@@ -25,6 +25,28 @@ while keeping the human/Claude quality gate on every pin.
 The user stocks the shelf with Claude occasionally; the schedule empties it
 automatically.
 
+## Stocking guidance (supply)
+
+The variety rotation can only shuffle what's stocked — it can't create variety
+the queue lacks. So stocking is treated as building a **backlog, not a batch**:
+
+- **Target a deep, multi-axis backlog (~20–30 approved pins)** per stocking
+  session rather than just enough for a few days. Generation is pennies; the
+  real cost is QA time, which is batched. A deep backlog gives the rotation
+  months of runway and the room to actually vary.
+- **Deliberately spread across all three axes** — `theme` (color/subject),
+  `format` (room/scene type), and `board` — so consecutive drips can differ.
+  Two supply sources feed this, both growable:
+  - **Pin scenes** — effectively unlimited: any color × any room/format is a new
+    pin via the `gemini-3-pro-image` pipeline.
+  - **Inspiration palettes** — the `/inspiration` pages (`src/lib/palettes.ts`,
+    18 today). New palettes double as new indexable site content AND new
+    pinnable source material; growing them widens the pool. (Drafting new
+    palettes is a parallel content task, tracked separately.)
+- **Cadence flexes to supply.** Default 2/day, but drop to 1/day when the
+  backlog is thin so a stocked set lasts longer. A deep backlog is the better
+  answer than a slow drip.
+
 ## Constraints
 
 - Runs on the user's Mac, which is on ~24/7 but often unattended.
@@ -73,10 +95,13 @@ generate → Claude QA → approve            launchd timer (9am + 5pm ET)
 - `PinSpec` gains:
   - a stable, globally-unique `key: string` (e.g. `"may26-01"`) for the
     published-state lookup;
-  - a `theme: string` variety tag (e.g. `"navy"`, `"warm-white"`, `"sage"`,
-    `"exterior"`, `"coty-2026"`, `"comparison"`) used by the variety rotation.
-  - (`board` already exists.) Both `board` and `theme` are assigned by Claude at
-    **stock** time when each batch is built — there is no auto-assignment.
+  - a `theme: string` tag = the color/subject (e.g. `"navy"`, `"warm-white"`,
+    `"sage"`, `"coty-2026"`);
+  - a `format: string` tag = the scene/room type (e.g. `"living-room"`,
+    `"kitchen"`, `"exterior"`, `"nursery"`, `"bathroom"`, `"comparison"`,
+    `"color-drench"`).
+  - (`board` already exists.) `board`, `theme`, and `format` are all assigned by
+    Claude at **stock** time when each batch is built — there is no auto-assignment.
 - New batches are added as new files and concatenated here. The queue file is
   the single source of "what is approved to publish."
 
@@ -99,16 +124,20 @@ generate → Claude QA → approve            launchd timer (9am + 5pm ET)
 **Variety rotation (selection logic).** Instead of walking the queue linearly,
 each pick maximizes variety so the feed reads as human-curated:
 1. Candidates = unpublished entries in `QUEUE`.
-2. Read the `theme` and `board` of the most recent publishes from
+2. Read the `theme`, `format`, and `board` of the most recent publishes from
    `published.json` (look back over the last `LOOKBACK = 3` publishes).
-3. Prefer a candidate whose `theme` is NOT in that recent window; among those,
-   prefer one whose `board` differs from the immediately previous publish.
+3. **Score each candidate by axis collisions** — count how many of its three
+   axes (`theme`, `format`, `board`) appear in that recent window. Pick the
+   lowest-collision candidate (most "different" from what just went out).
 4. Tie-break by `QUEUE` order (deterministic — same state always yields the same
    choice; no `Math.random`, which keeps the script resumable/testable).
-5. If every remaining candidate repeats a recent theme (small queue), relax the
-   theme constraint and fall back to queue order.
+5. This degrades gracefully: with a thin or homogeneous queue, every candidate
+   may collide, and the lowest-collision pick is simply taken in queue order.
+   The rotation *minimizes* repetition; it cannot manufacture variety the queue
+   doesn't contain (see Stocking guidance). Back-to-back similar pins are an
+   accepted, rare outcome, not a failure.
 For `--drip=N>1`, each pick within the run also counts toward "recent" so a
-single run won't post two of the same theme either.
+single run won't post two of the same theme/format either.
 
 **4. Schedule — `launchd` + wrapper**
 - `scripts/pinterest/drip.sh`: `cd` to the repo, run

--- a/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
+++ b/docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md
@@ -38,6 +38,9 @@ automatically.
 - **Blog post schedule** — separate subsystem, separate future spec. Same
   stock→drip shape will apply (draft + Claude reads/QAs + approve → scheduled
   publish), but blog "publish" is a git commit/deploy, so it needs its own design.
+  That spec will include **Nano Banana hero/cover image generation** for each
+  post, reusing the `gemini-3-pro-image` pipeline so one run produces both the
+  blog hero image and a matching Pinterest pin.
 - **The programmatic Vercel cron** (`/api/cron/pinterest-seed`) — stays OFF.
   Curated room-scenes are the brand's edge; plain `/api/pin` swatch pins would
   dilute the boards. Left intact in the codebase, simply not scheduled. May be
@@ -67,9 +70,13 @@ generate → Claude QA → approve            launchd timer (9am + 5pm ET)
 **1. Approved queue — `scripts/pinterest/queue.ts`**
 - Aggregates every approved batch array (starting with `batch-may26.ts`) into a
   single ordered `QUEUE: PinSpec[]` in intended publish order.
-- `PinSpec` gains a stable, globally-unique `key: string` (e.g. `"may26-01"`),
-  used for the published-state lookup. (Today the may26 entries are keyed
-  `may26-01`…`may26-10`.)
+- `PinSpec` gains:
+  - a stable, globally-unique `key: string` (e.g. `"may26-01"`) for the
+    published-state lookup;
+  - a `theme: string` variety tag (e.g. `"navy"`, `"warm-white"`, `"sage"`,
+    `"exterior"`, `"coty-2026"`, `"comparison"`) used by the variety rotation.
+  - (`board` already exists.) Both `board` and `theme` are assigned by Claude at
+    **stock** time when each batch is built — there is no auto-assignment.
 - New batches are added as new files and concatenated here. The queue file is
   the single source of "what is approved to publish."
 
@@ -81,12 +88,27 @@ generate → Claude QA → approve            launchd timer (9am + 5pm ET)
 - Gitignored (runtime state; pin IDs, not secrets).
 
 **3. Drip publisher — extend `scripts/pinterest-publish.ts`**
-- New mode `--drip=N`: select the first N entries in `QUEUE` whose `key` is not
-  in `published.json`, publish them, append results, exit. Reuses the existing
-  publish path (base64 upload, content-type sniff, 401→refresh, board mapping).
-- Existing `--only` / `--dry-run` retained for manual use and stock-time testing.
+- New mode `--drip=N`: publish N unpublished pins selected by the **variety
+  rotation** (below), append results, exit. Reuses the existing publish path
+  (base64 upload, content-type sniff, 401→refresh, board→ID mapping).
+- Existing `--only` / `--dry-run` retained for manual use and stock-time testing
+  (`--dry-run --drip=N` shows what *would* be selected, in order).
 - If 0 unpublished entries remain, publish nothing and emit the empty-queue
   signal (component 5).
+
+**Variety rotation (selection logic).** Instead of walking the queue linearly,
+each pick maximizes variety so the feed reads as human-curated:
+1. Candidates = unpublished entries in `QUEUE`.
+2. Read the `theme` and `board` of the most recent publishes from
+   `published.json` (look back over the last `LOOKBACK = 3` publishes).
+3. Prefer a candidate whose `theme` is NOT in that recent window; among those,
+   prefer one whose `board` differs from the immediately previous publish.
+4. Tie-break by `QUEUE` order (deterministic — same state always yields the same
+   choice; no `Math.random`, which keeps the script resumable/testable).
+5. If every remaining candidate repeats a recent theme (small queue), relax the
+   theme constraint and fall back to queue order.
+For `--drip=N>1`, each pick within the run also counts toward "recent" so a
+single run won't post two of the same theme either.
 
 **4. Schedule — `launchd` + wrapper**
 - `scripts/pinterest/drip.sh`: `cd` to the repo, run
@@ -114,7 +136,8 @@ generate → Claude QA → approve            launchd timer (9am + 5pm ET)
 
 1. launchd fires `drip.sh` at the scheduled time.
 2. Wrapper runs `pinterest-publish.ts --drip=1`.
-3. Script loads `QUEUE` + `published.json`, computes unpublished, takes the first 1.
+3. Script loads `QUEUE` + `published.json`, computes unpublished, and picks 1 via
+   the variety rotation (different theme/board from the last few publishes).
 4. Reads the local image, base64-encodes, `POST /v5/pins` (401→refresh→retry).
 5. Appends `{key: {pinId, publishedAt}}` to `published.json`.
 6. If nothing was unpublished, fires the empty-queue notification instead.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "compute-matches": "tsx scripts/compute-matches.ts",
     "seed-matches": "tsx scripts/seed-matches.ts",
     "populate-undertones": "tsx scripts/populate-undertones.ts",
-    "build-match-data": "tsx scripts/build-match-data.ts"
+    "build-match-data": "tsx scripts/build-match-data.ts",
+    "test:pinterest": "node --import tsx --test scripts/pinterest/queue.test.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.6.1",

--- a/scripts/pinterest-publish.ts
+++ b/scripts/pinterest-publish.ts
@@ -1,32 +1,46 @@
 /**
- * Pinterest publisher — creates pins from the batch definition + local images.
+ * Pinterest publisher — creates pins from the approved queue + local images.
  *
- * Reads scripts/pinterest/batch-may26.ts, matches each pin to its PNG in
+ * Reads scripts/pinterest/queue.ts (QUEUE), matches each pin to its PNG in
  * IMAGE_DIR, base64-encodes it, and POSTs to /v5/pins on the correct board
  * with title / description / UTM link.
  *
  * Requires an OAuth access token with pins:write (run pinterest-auth.ts first).
  * Auto-refreshes the access token on 401 using PINTEREST_REFRESH_TOKEN.
  *
- * A publish log (scripts/pinterest/published-may26.json) records pin id ->
+ * A global publish log (scripts/pinterest/published.json) records key ->
  * Pinterest pin id so re-runs never double-post.
  *
  * Usage:
- *   npx tsx scripts/pinterest-publish.ts --dry-run     # validate, no POST
- *   npx tsx scripts/pinterest-publish.ts --only=1,3    # publish pins 1 and 3
- *   npx tsx scripts/pinterest-publish.ts               # publish all unpublished
+ *   npx tsx scripts/pinterest-publish.ts --dry-run --drip=2  # show drip selection
+ *   npx tsx scripts/pinterest-publish.ts --drip=1            # publish next pin (variety rotation)
+ *   npx tsx scripts/pinterest-publish.ts --only=may26-01     # publish specific key(s)
+ *   npx tsx scripts/pinterest-publish.ts                     # publish all unpublished
  */
 import * as path from "path";
 import * as fs from "fs";
+import { execFile } from "child_process";
 import { fileURLToPath } from "url";
 import * as dotenv from "dotenv";
-import { BATCH, BOARD_IDS, IMAGE_DIR, type PinSpec } from "./pinterest/batch-may26.ts";
+import {
+  QUEUE,
+  BOARD_IDS,
+  IMAGE_DIR,
+  selectForDrip,
+  type PinSpec,
+  type PublishedLog,
+} from "./pinterest/queue.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ENV_PATH = path.resolve(__dirname, "../.env.local");
-const LOG_PATH = path.resolve(__dirname, "pinterest/published-may26.json");
+const LOG_PATH = path.resolve(__dirname, "pinterest/published.json");
 dotenv.config({ path: ENV_PATH });
+
+/** macOS local notification — best-effort, never throws. */
+function notify(message: string) {
+  execFile("osascript", ["-e", `display notification "${message.replace(/"/g, "'")}" with title "PaintColorHQ"`], () => {});
+}
 
 const APP_ID = process.env.PINTEREST_APP_ID!;
 const APP_SECRET = process.env.PINTEREST_APP_SECRET_KEY!;
@@ -35,10 +49,10 @@ const API = "https://api.pinterest.com/v5";
 // ---- CLI args ----
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes("--dry-run");
+const dripArg = args.find((a) => a.startsWith("--drip="));
+const DRIP = dripArg ? Math.max(1, parseInt(dripArg.replace("--drip=", ""), 10) || 1) : null;
 const onlyArg = args.find((a) => a.startsWith("--only="));
-const onlyIds = onlyArg
-  ? new Set(onlyArg.replace("--only=", "").split(",").map((n) => parseInt(n, 10)))
-  : null;
+const onlyKeys = onlyArg ? new Set(onlyArg.replace("--only=", "").split(",")) : null;
 
 // ---- env + log helpers ----
 function upsertEnv(updates: Record<string, string>) {
@@ -52,15 +66,14 @@ function upsertEnv(updates: Record<string, string>) {
   fs.writeFileSync(ENV_PATH, lines.join("\n"));
 }
 
-type PublishLog = Record<string, { pinId: string; publishedAt: string }>;
-function loadLog(): PublishLog {
+function loadLog(): PublishedLog {
   try {
     return JSON.parse(fs.readFileSync(LOG_PATH, "utf8"));
   } catch {
     return {};
   }
 }
-function saveLog(log: PublishLog) {
+function saveLog(log: PublishedLog) {
   fs.writeFileSync(LOG_PATH, JSON.stringify(log, null, 2) + "\n");
 }
 
@@ -112,10 +125,10 @@ function imagePayload(pin: PinSpec) {
   return { source_type: "image_base64" as const, content_type: contentType, data: buf.toString("base64") };
 }
 
-async function publishPin(pin: PinSpec, log: PublishLog) {
-  const tag = `#${pin.id} ${pin.name}`;
-  if (log[pin.id]) {
-    console.log(`⏭️  ${tag} — already published (pin ${log[pin.id].pinId})`);
+async function publishPin(pin: PinSpec, log: PublishedLog) {
+  const tag = `${pin.key} ${pin.name}`;
+  if (log[pin.key]) {
+    console.log(`⏭️  ${tag} — already published (pin ${log[pin.key].pinId})`);
     return;
   }
   const boardId = BOARD_IDS[pin.board];
@@ -141,22 +154,33 @@ async function publishPin(pin: PinSpec, log: PublishLog) {
       media_source: media,
     }),
   });
-  log[pin.id] = { pinId: result.id, publishedAt: new Date().toISOString() };
+  log[pin.key] = { pinId: result.id, publishedAt: new Date().toISOString() };
   saveLog(log);
   console.log(`✅ ${tag} → pin ${result.id} on ${pin.board}`);
 }
 
 async function main() {
   const log = loadLog();
-  const targets = BATCH.filter((p) => (onlyIds ? onlyIds.has(p.id) : true));
+  let targets: PinSpec[];
+  if (DRIP) {
+    targets = selectForDrip(QUEUE, log, DRIP);
+    if (targets.length === 0) {
+      console.log("Drip: queue empty — nothing unpublished to post.");
+      if (!DRY_RUN) notify("Pinterest queue empty — stock more with Claude.");
+      return;
+    }
+  } else {
+    targets = QUEUE.filter((p) => (onlyKeys ? onlyKeys.has(p.key) : true));
+  }
   console.log(
-    `${DRY_RUN ? "DRY RUN — " : ""}Publishing ${targets.length} pin(s)${onlyIds ? ` (--only=${[...onlyIds].join(",")})` : ""}\n`
+    `${DRY_RUN ? "DRY RUN — " : ""}Publishing ${targets.length} pin(s)` +
+      `${DRIP ? " (drip, variety rotation)" : onlyKeys ? ` (--only=${[...onlyKeys].join(",")})` : ""}\n`
   );
   for (const pin of targets) {
     try {
       await publishPin(pin, log);
     } catch (e) {
-      console.error(`❌ #${pin.id} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+      console.error(`❌ ${pin.key} ${pin.name}: ${e instanceof Error ? e.message : e}`);
     }
     // gentle spacing to stay clear of rate limits
     if (!DRY_RUN) await new Promise((r) => setTimeout(r, 2500));

--- a/scripts/pinterest-publish.ts
+++ b/scripts/pinterest-publish.ts
@@ -139,6 +139,7 @@ async function publishPin(pin: PinSpec, log: PublishedLog) {
     console.log(`     board:  ${pin.board} (${boardId})`);
     console.log(`     title:  ${pin.title}  [${pin.title.length} chars]`);
     console.log(`     link:   ${pin.link}`);
+    // base64 inflates raw bytes by ~4/3 (1.37), so divide it back out for the raw-size estimate
     console.log(`     image:  ${pin.image} (${media.content_type}, ${(media.data.length / 1.37 / 1024 / 1024).toFixed(1)}MB)`);
     return;
   }
@@ -180,7 +181,13 @@ async function main() {
     try {
       await publishPin(pin, log);
     } catch (e) {
-      console.error(`❌ ${pin.key} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`❌ ${pin.key} ${pin.name}: ${msg}`);
+      // Surface auth/token failures — the drip runs unattended, so a silent
+      // log entry would never reach the user.
+      if (!DRY_RUN && /refresh|token|\b401\b|sufficient permissions/i.test(msg)) {
+        notify("Pinterest auth failed — re-run pinterest-auth.ts");
+      }
     }
     // gentle spacing to stay clear of rate limits
     if (!DRY_RUN) await new Promise((r) => setTimeout(r, 2500));

--- a/scripts/pinterest/batch-may26.ts
+++ b/scripts/pinterest/batch-may26.ts
@@ -19,6 +19,12 @@ export const BOARD_IDS: Record<BoardName, string> = {
 export interface PinSpec {
   /** 1-based position in the batch. */
   id: number;
+  /** Stable, globally-unique key across all batches (e.g. "may26-01"). */
+  key: string;
+  /** Variety axis — color/subject (e.g. "navy", "white", "sage"). */
+  theme: string;
+  /** Variety axis — scene/room type (e.g. "living-room", "kitchen", "exterior"). */
+  format: string;
   /** Human label. */
   name: string;
   /** Image filename inside IMAGE_DIR (matches the existing Desktop PNGs). */
@@ -43,6 +49,9 @@ const UTM = "?utm_source=Pinterest&utm_medium=organic&utm_campaign=may26-pin-bat
 export const BATCH: PinSpec[] = [
   {
     id: 1,
+    key: "may26-01",
+    theme: "navy",
+    format: "living-room",
     name: "Hale Navy Living Room",
     image: "Hale Navy Living Room.png",
     prompt:
@@ -55,6 +64,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 2,
+    key: "may26-02",
+    theme: "warm-gray",
+    format: "kitchen",
     name: "Agreeable Gray Open-Plan Kitchen",
     image: "Agreeable Gray Open-Plan Kitchen.png",
     prompt:
@@ -67,6 +79,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 3,
+    key: "may26-03",
+    theme: "soft-black",
+    format: "exterior",
     name: "Iron Ore Front Door",
     image: "Iron Ore Front Door.png",
     prompt:
@@ -79,6 +94,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 4,
+    key: "may26-04",
+    theme: "white",
+    format: "comparison",
     name: "Best Whites Side-by-Side",
     image: "Best Whites Side-by-Side.png",
     prompt:
@@ -91,6 +109,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 5,
+    key: "may26-05",
+    theme: "sage",
+    format: "bathroom",
     name: "Sage Bathroom",
     image: "Sage Bathroom.png",
     prompt:
@@ -103,6 +124,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 6,
+    key: "may26-06",
+    theme: "navy",
+    format: "kitchen",
     name: "Naval Kitchen Cabinets",
     image: "Naval Kitchen Cabinets.png",
     prompt:
@@ -115,6 +139,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 7,
+    key: "may26-07",
+    theme: "pink",
+    format: "nursery",
     name: "Pink Hydrangea Nursery",
     image: "Pink Hydrangea Nursery.png",
     prompt:
@@ -127,6 +154,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 8,
+    key: "may26-08",
+    theme: "plum-brown",
+    format: "dining-room",
     name: "Cinnamon Slate Dining Room",
     image: "Cinnamon Slate Dining Room.png",
     prompt:
@@ -139,6 +169,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 9,
+    key: "may26-09",
+    theme: "green",
+    format: "color-drench",
     name: "Hidden Gem Mudroom (Color-Drenched)",
     image: "Hidden Gem Mudroom (Color-Drenched).png",
     prompt:
@@ -151,6 +184,9 @@ export const BATCH: PinSpec[] = [
   },
   {
     id: 10,
+    key: "may26-10",
+    theme: "blue-green",
+    format: "kitchen",
     name: "Sea Salt Cottage Kitchen",
     image: "Sea Salt Cottage Kitchen.png",
     prompt:

--- a/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template
+++ b/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>__LABEL__</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__DRIPSH__</string>
+    <string>1</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>__NODE_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+  </array>
+  <key>StandardErrorPath</key><string>__REPO__/scripts/pinterest/drip.log</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/pinterest/drip.sh
+++ b/scripts/pinterest/drip.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# launchd entry point for the Pinterest drip. Resolves the repo root from its
+# own location, then publishes one pin via the variety rotation. Logs to drip.log.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+COUNT="${1:-1}"
+echo "=== drip run $(date -u +%Y-%m-%dT%H:%M:%SZ) (count=$COUNT) ===" >> "$REPO/scripts/pinterest/drip.log"
+npx tsx scripts/pinterest-publish.ts --drip="$COUNT" >> "$REPO/scripts/pinterest/drip.log" 2>&1

--- a/scripts/pinterest/install-drip-schedule.sh
+++ b/scripts/pinterest/install-drip-schedule.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Render the launchd plist with this machine's paths and (un)load it.
+# Run this from the PERMANENT repo checkout (not a temporary worktree), since
+# the launchd agent will reference whatever path this resolves to.
+#
+# Usage: ./install-drip-schedule.sh           # install
+#        ./install-drip-schedule.sh uninstall # remove
+set -euo pipefail
+LABEL="com.paintcolorhq.pinterest-drip"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if [[ "${1:-}" == "uninstall" ]]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "Uninstalled $LABEL."
+  exit 0
+fi
+
+DRIPSH="$REPO/scripts/pinterest/drip.sh"
+NODE_DIR="$(dirname "$(command -v node)")"
+chmod +x "$DRIPSH"
+mkdir -p "$HOME/Library/LaunchAgents"
+sed -e "s|__LABEL__|$LABEL|g" \
+    -e "s|__DRIPSH__|$DRIPSH|g" \
+    -e "s|__NODE_DIR__|$NODE_DIR|g" \
+    -e "s|__REPO__|$REPO|g" \
+    "$REPO/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template" > "$PLIST"
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+echo "Installed $LABEL — drips 1 pin at 13:00 and 21:00 UTC (9am/5pm EDT)."
+echo "Repo: $REPO"
+echo "Logs: $REPO/scripts/pinterest/drip.log"
+echo "Uninstall: ./scripts/pinterest/install-drip-schedule.sh uninstall"

--- a/scripts/pinterest/queue.test.ts
+++ b/scripts/pinterest/queue.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  unpublished,
+  collisionScore,
+  pickNext,
+  selectForDrip,
+  type PinSpec,
+  type PublishedLog,
+} from "./queue.ts";
+
+// Minimal PinSpec stub — only the fields the selection layer reads.
+function mk(key: string, theme: string, format: string, board: PinSpec["board"]): PinSpec {
+  return { key, theme, format, board } as unknown as PinSpec;
+}
+
+const Q: PinSpec[] = [
+  mk("a", "navy", "living-room", "Color Palettes"),
+  mk("b", "navy", "kitchen", "Color Palettes"),
+  mk("c", "sage", "bathroom", "Color Palettes"),
+  mk("d", "white", "comparison", "Paint Color Guides"),
+];
+
+test("unpublished filters out keys present in the log", () => {
+  const log: PublishedLog = { a: { pinId: "1", publishedAt: "2026-05-30T00:00:00Z" } };
+  assert.deepEqual(unpublished(Q, log).map((p) => p.key), ["b", "c", "d"]);
+});
+
+test("collisionScore counts shared theme/format/board", () => {
+  const recent = [mk("a", "navy", "living-room", "Color Palettes")];
+  assert.equal(collisionScore(mk("x", "navy", "kitchen", "Color Palettes"), recent), 2); // theme+board
+  assert.equal(collisionScore(mk("y", "white", "comparison", "Paint Color Guides"), recent), 0);
+});
+
+test("pickNext prefers lowest collision, tie-breaks by queue order", () => {
+  const recent = [mk("a", "navy", "living-room", "Color Palettes")];
+  assert.equal(pickNext([Q[1], Q[2], Q[3]], recent)!.key, "d");
+  assert.equal(pickNext([Q[1], Q[2], Q[3]], [])!.key, "b");
+});
+
+test("selectForDrip returns [] when everything is published", () => {
+  const log: PublishedLog = Object.fromEntries(
+    Q.map((p) => [p.key, { pinId: "x", publishedAt: "2026-05-30T00:00:00Z" }]),
+  );
+  assert.deepEqual(selectForDrip(Q, log, 2), []);
+});
+
+test("selectForDrip(N=2) does not pick two of the same theme back-to-back", () => {
+  const picks = selectForDrip(Q, {}, 2).map((p) => p.key);
+  assert.equal(picks[0], "a");
+  assert.notEqual(picks[1], "b");
+  assert.equal(picks[1], "c");
+});

--- a/scripts/pinterest/queue.test.ts
+++ b/scripts/pinterest/queue.test.ts
@@ -49,5 +49,5 @@ test("selectForDrip(N=2) does not pick two of the same theme back-to-back", () =
   const picks = selectForDrip(Q, {}, 2).map((p) => p.key);
   assert.equal(picks[0], "a");
   assert.notEqual(picks[1], "b");
-  assert.equal(picks[1], "c");
+  assert.equal(picks[1], "d");
 });

--- a/scripts/pinterest/queue.ts
+++ b/scripts/pinterest/queue.ts
@@ -70,14 +70,8 @@ export function selectForDrip(
   const prior = recentlyPublished(queue, published, lookback); // newest first
   let pool = unpublished(queue, published);
   for (let i = 0; i < count; i++) {
-    // Variety context: prior published items (external history) drives collision scoring.
-    const window = prior.slice(0, lookback);
-    // Hard-block same theme as the immediately preceding pick to prevent back-to-back
-    // repeats; fall back to the full pool only if every remaining pin shares that theme.
-    const lastTheme = chosen.length > 0 ? chosen[chosen.length - 1].theme : null;
-    const themePool = lastTheme ? pool.filter((p) => p.theme !== lastTheme) : pool;
-    const effectivePool = themePool.length > 0 ? themePool : pool;
-    const next = pickNext(effectivePool, window);
+    const window = [...chosen].reverse().concat(prior).slice(0, lookback);
+    const next = pickNext(pool, window);
     if (!next) break;
     chosen.push(next);
     pool = pool.filter((p) => p.key !== next.key);

--- a/scripts/pinterest/queue.ts
+++ b/scripts/pinterest/queue.ts
@@ -1,0 +1,86 @@
+// Aggregated, approved Pinterest pin queue + variety-rotation selection.
+// Pure functions only — no I/O — so the drip logic is unit-testable.
+
+import { BATCH as MAY26 } from "./batch-may26.ts";
+export { BOARD_IDS, IMAGE_DIR } from "./batch-may26.ts";
+export type { PinSpec, BoardName } from "./batch-may26.ts";
+import type { PinSpec } from "./batch-may26.ts";
+
+/** All approved batches, concatenated in intended publish order. */
+export const QUEUE: PinSpec[] = [...MAY26];
+
+export type PublishedLog = Record<string, { pinId: string; publishedAt: string }>;
+
+export const LOOKBACK = 3;
+
+/** Queue entries whose key is not yet in the published log, in queue order. */
+export function unpublished(queue: PinSpec[], published: PublishedLog): PinSpec[] {
+  return queue.filter((p) => !(p.key in published));
+}
+
+/** The most recently published specs (newest first), capped to `lookback`. */
+export function recentlyPublished(
+  queue: PinSpec[],
+  published: PublishedLog,
+  lookback: number,
+): PinSpec[] {
+  const byKey = new Map(queue.map((p) => [p.key, p]));
+  return Object.entries(published)
+    .filter(([key]) => byKey.has(key))
+    .sort((a, b) => (a[1].publishedAt < b[1].publishedAt ? 1 : -1)) // newest first
+    .slice(0, lookback)
+    .map(([key]) => byKey.get(key)!);
+}
+
+/** How many of {theme, format, board} a candidate shares with the recent window. */
+export function collisionScore(candidate: PinSpec, recent: PinSpec[]): number {
+  const themes = new Set(recent.map((r) => r.theme));
+  const formats = new Set(recent.map((r) => r.format));
+  const boards = new Set(recent.map((r) => r.board));
+  return (
+    (themes.has(candidate.theme) ? 1 : 0) +
+    (formats.has(candidate.format) ? 1 : 0) +
+    (boards.has(candidate.board) ? 1 : 0)
+  );
+}
+
+/** Lowest-collision candidate; ties keep the earliest (queue order). */
+export function pickNext(candidates: PinSpec[], recent: PinSpec[]): PinSpec | null {
+  if (candidates.length === 0) return null;
+  let best = candidates[0];
+  let bestScore = collisionScore(best, recent);
+  for (const c of candidates.slice(1)) {
+    const s = collisionScore(c, recent);
+    if (s < bestScore) {
+      best = c;
+      bestScore = s;
+    }
+  }
+  return best;
+}
+
+/** Pick `count` unpublished pins via the variety rotation. */
+export function selectForDrip(
+  queue: PinSpec[],
+  published: PublishedLog,
+  count: number,
+  lookback = LOOKBACK,
+): PinSpec[] {
+  const chosen: PinSpec[] = [];
+  const prior = recentlyPublished(queue, published, lookback); // newest first
+  let pool = unpublished(queue, published);
+  for (let i = 0; i < count; i++) {
+    // Variety context: prior published items (external history) drives collision scoring.
+    const window = prior.slice(0, lookback);
+    // Hard-block same theme as the immediately preceding pick to prevent back-to-back
+    // repeats; fall back to the full pool only if every remaining pin shares that theme.
+    const lastTheme = chosen.length > 0 ? chosen[chosen.length - 1].theme : null;
+    const themePool = lastTheme ? pool.filter((p) => p.theme !== lastTheme) : pool;
+    const effectivePool = themePool.length > 0 ? themePool : pool;
+    const next = pickNext(effectivePool, window);
+    if (!next) break;
+    chosen.push(next);
+    pool = pool.filter((p) => p.key !== next.key);
+  }
+  return chosen;
+}


### PR DESCRIPTION
## What

The **drip half** of the curated Pinterest pipeline: publishes pre-approved pins on an unattended 2×/day schedule from the local Mac, selecting each by a variety rotation. Generation + QA stay Claude-in-the-loop (unchanged); this only automates publishing of already-vetted pins.

Spec: `docs/superpowers/specs/2026-05-30-pinterest-drip-schedule-design.md`
Plan: `docs/superpowers/plans/2026-05-30-pinterest-drip-schedule.md`

## Implementation (Tasks 1–6)

- **`PinSpec` + tags** — added `key`/`theme`/`format`; tagged all 10 may26 pins.
- **`queue.ts`** — aggregates batches into `QUEUE`; pure, **unit-tested** variety selection (`node:test`, 5 tests). Scores candidates by collisions across theme/format/board and picks the most-different; deterministic, no RNG.
- **Keyed `published.json`** — migrated from id-keyed `published-may26.json`; gitignored along with `drip.log`.
- **`--drip=N`** on the publisher — variety selection on the global queue, empty-queue macOS notification, token auto-refresh. `--only`/`--dry-run` retained.
- **`drip.sh`** launchd wrapper + **plist template** + **install/uninstall script**.

## Verified

- `npm run test:pinterest` → 5/5 pass (incl. "no two same-theme back-to-back").
- Dry-run drip on a stocked fixture selects the correct unpublished pin with right board/title/link.
- Wrapper smoke-tested; empty-queue path logs + notifies safely.
- Since the may26 batch is fully published, the queue starts **empty** — the schedule safely no-ops and signals "stock more" until the next curated batch is approved. Nothing can accidentally post.

## Remaining (Task 7, post-merge)

`launchctl` install must run from the permanent main checkout (not a worktree):
`./scripts/pinterest/install-drip-schedule.sh` — drips at 13:00 & 21:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)