### PR TITLE
feat(pinterest): June restock — 30 curated pins (2×15) + queue wiring

### DIFF
--- a/scripts/pinterest-generate.ts
+++ b/scripts/pinterest-generate.ts
@@ -21,7 +21,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { fileURLToPath } from "url";
 import * as dotenv from "dotenv";
-import { BATCH, IMAGE_DIR, type PinSpec } from "./pinterest/batch-may26.ts";
+import { QUEUE, IMAGE_DIR, type PinSpec } from "./pinterest/queue.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,14 +38,12 @@ if (!API_KEY) {
 const args = process.argv.slice(2);
 const FORCE = args.includes("--force");
 const onlyArg = args.find((a) => a.startsWith("--only="));
-const onlyIds = onlyArg
-  ? new Set(onlyArg.replace("--only=", "").split(",").map((n) => parseInt(n, 10)))
-  : null;
+const onlyKeys = onlyArg ? new Set(onlyArg.replace("--only=", "").split(",")) : null;
 
 async function generate(pin: PinSpec) {
   const out = path.join(IMAGE_DIR, pin.image);
-  if (fs.existsSync(out) && !FORCE && !onlyIds) {
-    console.log(`⏭️  #${pin.id} ${pin.name} — exists (use --force to overwrite)`);
+  if (fs.existsSync(out) && !FORCE && !onlyKeys) {
+    console.log(`⏭️  ${pin.key} ${pin.name} — exists (use --force to overwrite)`);
     return;
   }
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${API_KEY}`;
@@ -71,17 +69,17 @@ async function generate(pin: PinSpec) {
   fs.mkdirSync(IMAGE_DIR, { recursive: true });
   fs.writeFileSync(out, Buffer.from(img.data, "base64"));
   const mb = (Buffer.from(img.data, "base64").length / 1024 / 1024).toFixed(1);
-  console.log(`✅ #${pin.id} ${pin.name} → ${pin.image} (${img.mimeType}, ${mb}MB)`);
+  console.log(`✅ ${pin.key} ${pin.name} → ${pin.image} (${img.mimeType}, ${mb}MB)`);
 }
 
 async function main() {
-  const targets = BATCH.filter((p) => (onlyIds ? onlyIds.has(p.id) : true));
+  const targets = QUEUE.filter((p) => (onlyKeys ? onlyKeys.has(p.key) : true));
   console.log(`Generating ${targets.length} image(s) with ${MODEL} at 2:3\n`);
   for (const pin of targets) {
     try {
       await generate(pin);
     } catch (e) {
-      console.error(`❌ #${pin.id} ${pin.name}: ${e instanceof Error ? e.message : e}`);
+      console.error(`❌ ${pin.key} ${pin.name}: ${e instanceof Error ? e.message : e}`);
     }
   }
   console.log("\nDone. Next: have Claude QA the images, then publish.");

--- a/scripts/pinterest/batch-jun-restock-2.ts
+++ b/scripts/pinterest/batch-jun-restock-2.ts
@@ -1,0 +1,249 @@
+// Pinterest batch — June 2026 restock, part 2 (campaign: restock-jun-2026)
+// Continues restock-01..15 with keys restock-16..30. All color data verified
+// against the live DB on 2026-05-30; cross-brand picks (Behr/Valspar/PPG/DE)
+// swapped to in-DB colors where the first-choice name wasn't carried.
+// Reuses buildPrompt() from batch-jun-restock.ts for identical rendering rules.
+
+import type { PinSpec } from "./batch-may26.ts";
+import { buildPrompt, type Swatch } from "./batch-jun-restock.ts";
+
+const C = {
+  gentlemansGray: { name: "Gentleman's Gray", hex: "#314757", rgb: "49, 71, 87", lrv: "5.8", undertone: "Cool Blue" },
+  oysterBay: { name: "Oyster Bay", hex: "#AEB3A9", rgb: "174, 179, 169", lrv: "44.1", undertone: "Warm Golden" },
+  swissCoffee: { name: "Swiss Coffee", hex: "#F2F1E5", rgb: "242, 241, 229", lrv: "87.4", undertone: "Neutral" },
+  filteredShade: { name: "Filtered Shade", hex: "#CDCBC8", rgb: "205, 203, 200", lrv: "59.9", undertone: "Neutral" },
+  oliveSprig: { name: "Olive Sprig", hex: "#ACAF95", rgb: "172, 175, 149", lrv: "41.6", undertone: "Cool Green" },
+  kendallCharcoal: { name: "Kendall Charcoal", hex: "#686763", rgb: "104, 103, 99", lrv: "13.5", undertone: "Neutral" },
+  bayFog: { name: "Bay Fog", hex: "#9899B0", rgb: "152, 153, 176", lrv: "32.6", undertone: "Cool Violet" },
+  gauntletGray: { name: "Gauntlet Gray", hex: "#78736E", rgb: "120, 115, 110", lrv: "17.4", undertone: "Warm Golden" },
+  caliente: { name: "Caliente", hex: "#8B2829", rgb: "139, 40, 41", lrv: "7.2", undertone: "Warm" },
+  rainwashed: { name: "Rainwashed", hex: "#C2CDC5", rgb: "194, 205, 197", lrv: "59.2", undertone: "Neutral" },
+  palladianBlue: { name: "Palladian Blue", hex: "#C2D2CA", rgb: "194, 210, 202", lrv: "61.8", undertone: "Neutral" },
+  paleTaupe: { name: "Pale Taupe", hex: "#E3D1C8", rgb: "227, 209, 200", lrv: "66.1", undertone: "Neutral" },
+  shakerBeige: { name: "Shaker Beige", hex: "#D2C3A8", rgb: "210, 195, 168", lrv: "53.5", undertone: "Neutral" },
+  // supporting + comparison colors (verified in prior batches)
+  greekVilla: { name: "Greek Villa", hex: "#F0ECE2", rgb: "240, 236, 226", lrv: "84", undertone: "Neutral" },
+  alabaster: { name: "Alabaster", hex: "#EDEAE0", rgb: "237, 234, 224", lrv: "82.2", undertone: "Neutral" },
+  haleNavy: { name: "Hale Navy", hex: "#3E4450", rgb: "62, 68, 80", lrv: "7.1", undertone: "Cool Blue" },
+  naval: { name: "Naval", hex: "#34405A", rgb: "52, 64, 90", lrv: "4.5", undertone: "Cool Blue" },
+  newburyportBlue: { name: "Newburyport Blue", hex: "#475667", rgb: "71, 86, 103", lrv: "9", undertone: "Neutral" },
+  evergreenFog: { name: "Evergreen Fog", hex: "#95A18D", rgb: "149, 161, 141", lrv: "30", undertone: "Cool Green" },
+  pewterGreen: { name: "Pewter Green", hex: "#5E6259", rgb: "94, 98, 89", lrv: "11.8", undertone: "Warm Golden" },
+  saybrookSage: { name: "Saybrook Sage", hex: "#B2BAA4", rgb: "178, 186, 164", lrv: "46.4", undertone: "Cool Green" },
+} satisfies Record<string, Swatch>;
+
+const UTM = "?utm_source=Pinterest&utm_medium=organic&utm_campaign=restock-jun-2026";
+const SITE = "https://www.paintcolorhq.com";
+
+export const BATCH: PinSpec[] = [
+  {
+    id: 16, key: "restock-16", theme: "navy", format: "wet-bar",
+    name: "Gentleman's Gray Wet Bar",
+    image: "Gentlemans Gray Wet Bar.png",
+    prompt: buildPrompt(
+      "A moody home wet bar color-drenched in Gentleman's Gray — the cabinetry, walls, and open shelving are all painted Gentleman's Gray (deep teal-navy). The crown molding and counter backsplash trim are painted Greek Villa. Honed marble counter, unlacquered brass bar faucet and hardware, amber glassware and decanters on the brass shelving, warm focused lighting.",
+      [C.gentlemansGray, C.greekVilla],
+    ),
+    title: "Gentleman's Gray Wet Bar — BM 2062-20 Deep Teal-Navy",
+    description:
+      "Benjamin Moore Gentleman's Gray 2062-20 (LRV 5.8) color-drenched on a home wet bar — a deep teal-navy that turns a small alcove into a jewel box. Honed marble, unlacquered brass, and amber glass do the rest. Greek Villa keeps the trim crisp. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/gentlemans-gray-2062-20${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 17, key: "restock-17", theme: "sage", format: "primary-bath",
+    name: "Oyster Bay Primary Bath",
+    image: "Oyster Bay Primary Bath.png",
+    prompt: buildPrompt(
+      "A spa-like primary bathroom. The walls are painted Oyster Bay (soft sage-green-gray). The trim, ceiling, and freestanding-tub millwork are painted Greek Villa. A freestanding soaking tub, polished nickel floor-mount filler, white oak vanity, marble-look floor tile, and eucalyptus in a stoneware vase. Soft even daylight.",
+      [C.oysterBay, C.greekVilla],
+    ),
+    title: "Oyster Bay Primary Bath — SW 6206 Spa Sage-Green",
+    description:
+      "Sherwin-Williams Oyster Bay SW 6206 (LRV 44.1) is the soft sage-green-gray that gives a primary bath a calm, spa-like feel — green enough to soothe, gray enough to stay sophisticated. Paired with Greek Villa trim, white oak, and polished nickel. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/oyster-bay-6206${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 18, key: "restock-18", theme: "warm-white", format: "great-room",
+    name: "Swiss Coffee Great Room",
+    image: "Swiss Coffee Great Room.png",
+    prompt: buildPrompt(
+      "A bright open-plan great room. The walls and ceiling are painted Swiss Coffee (creamy warm white). The steel-framed windows and a slim fireplace surround are painted Kendall Charcoal as the dark contrast. A large sectional in oatmeal linen, a walnut coffee table, a jute rug, and abundant daylight from tall windows.",
+      [C.swissCoffee, C.kendallCharcoal],
+    ),
+    title: "Swiss Coffee Great Room — Behr's Warm White Open-Plan",
+    description:
+      "Behr Swiss Coffee W-B-700 (LRV 87.4) is the creamy warm white that keeps a big open-plan great room bright without the glare of a stark white. Kendall Charcoal on the steel windows and fireplace adds the contrast. The most-loved Behr white for a reason. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/behr/swiss-coffee-w-b-700${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 19, key: "restock-19", theme: "soft-gray", format: "laundry-room",
+    name: "Filtered Shade Laundry Room",
+    image: "Filtered Shade Laundry Room.png",
+    prompt: buildPrompt(
+      "A bright laundry room. The walls are painted Filtered Shade (soft neutral gray). The shaker cabinets and trim are painted Swiss Coffee. A white quartz folding counter, brushed nickel hardware, a woven basket, a patterned cement floor tile, and a window over the sink with natural light.",
+      [C.filteredShade, C.swissCoffee],
+    ),
+    title: "Filtered Shade Laundry Room — Valspar Soft Gray",
+    description:
+      "Valspar Filtered Shade 4003-1B (LRV 59.9) is the clean, soft neutral gray that keeps a laundry room feeling crisp and bright — no blue or green cast to fight the cabinets. Paired with Swiss Coffee cabinetry, quartz, and patterned cement tile. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/valspar/filtered-shade-4003-1b${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 20, key: "restock-20", theme: "green", format: "playroom",
+    name: "Olive Sprig Playroom",
+    image: "Olive Sprig Playroom.png",
+    prompt: buildPrompt(
+      "A cheerful kids' playroom. The walls are painted Olive Sprig (muted sage green). The trim, built-in toy shelving, and window seat are painted Greek Villa. A natural-wood play table, woven storage baskets, a soft wool rug, a few potted plants on a high shelf, and bright daylight.",
+      [C.oliveSprig, C.greekVilla],
+    ),
+    title: "Olive Sprig Playroom — PPG Muted Sage Green",
+    description:
+      "PPG Olive Sprig 1125-4 (LRV 41.6) is a muted sage green that makes a kids' playroom feel calm and grown-up rather than primary-color loud — a color the room won't outgrow. Paired with Greek Villa built-ins, natural wood, and woven storage. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/ppg/olive-sprig-1125-4${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 21, key: "restock-21", theme: "charcoal", format: "fireplace",
+    name: "Kendall Charcoal Fireplace Wall",
+    image: "Kendall Charcoal Fireplace Wall.png",
+    prompt: buildPrompt(
+      "A living room with a floor-to-ceiling fireplace feature wall painted Kendall Charcoal (warm deep charcoal). The surrounding walls, trim, and ceiling are painted Greek Villa. A white oak mantel, a pair of cream bouclé chairs, a jute rug, brass picture light over framed art, and warm evening lamplight.",
+      [C.kendallCharcoal, C.greekVilla],
+    ),
+    title: "Kendall Charcoal Fireplace Wall — BM HC-166 Warm Charcoal",
+    description:
+      "Benjamin Moore Kendall Charcoal HC-166 (LRV 13.5) on a fireplace feature wall — a warm deep charcoal that anchors a living room without the flatness of black. Greek Villa on the surrounding walls lets it stand out. White oak, bouclé, and brass complete it. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/kendall-charcoal-hc-166${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 22, key: "restock-22", theme: "blue-gray", format: "craft-room",
+    name: "Bay Fog Craft Room",
+    image: "Bay Fog Craft Room.png",
+    prompt: buildPrompt(
+      "A tidy craft room. The walls are painted Bay Fog (soft blue-violet gray). The built-in cabinets, pegboard frame, and trim are painted Swiss Coffee. A white quartz worktable, open shelving with labeled jars and rolls of ribbon, a rattan stool, and bright north-facing daylight.",
+      [C.bayFog, C.swissCoffee],
+    ),
+    title: "Bay Fog Craft Room — Dunn-Edwards Soft Blue-Gray",
+    description:
+      "Dunn-Edwards Bay Fog DE5934 (LRV 32.6) is a soft blue-violet gray that makes a craft room feel focused and calm — a quiet backdrop that lets colorful supplies pop. Paired with Swiss Coffee cabinetry and quartz. Cross-brand matches across 14 brands at PaintColorHQ.",
+    link: `${SITE}/colors/dunn-edwards/bay-fog-de5934${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 23, key: "restock-23", theme: "dark-gray", format: "media-room",
+    name: "Gauntlet Gray Media Room",
+    image: "Gauntlet Gray Media Room.png",
+    prompt: buildPrompt(
+      "A cozy media room. The walls and ceiling are painted Gauntlet Gray (deep warm gray). The trim and a built-in media console are painted Greek Villa. A deep charcoal sectional, a wool flatweave rug, brass sconces dimmed low, blackout linen drapes, and warm low lighting.",
+      [C.gauntletGray, C.greekVilla],
+    ),
+    title: "Gauntlet Gray Media Room — SW 7019 Deep Warm Gray",
+    description:
+      "Sherwin-Williams Gauntlet Gray SW 7019 (LRV 17.4) wraps a media room in a deep warm gray that cuts screen glare and feels enveloping without going full black. Greek Villa trim keeps the edges defined. Charcoal seating and dimmed brass complete the cocoon. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/gauntlet-gray-7019${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 24, key: "restock-24", theme: "red", format: "front-door",
+    name: "Caliente Front Door",
+    image: "Caliente Front Door.png",
+    prompt: buildPrompt(
+      "A welcoming home entrance. The front door is painted Caliente (bold lipstick red). The siding and trim around the door are painted Alabaster. A brass door knocker and handle, two black planters with topiaries flanking the door, a slate stoop, and bright midday light.",
+      [C.caliente, C.alabaster],
+    ),
+    title: "Caliente Front Door — Benjamin Moore AF-290 Bold Red",
+    description:
+      "Benjamin Moore Caliente AF-290 (LRV 7.2) — the 2018 Color of the Year — is the confident lipstick red that makes a front door the focal point of the whole facade. Set against Alabaster siding with brass hardware and topiaries. See cross-brand red matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/caliente-af-290${UTM}`,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 25, key: "restock-25", theme: "blue-green", format: "screened-porch",
+    name: "Rainwashed Screened Porch",
+    image: "Rainwashed Screened Porch.png",
+    prompt: buildPrompt(
+      "A relaxed screened porch. The walls and tongue-and-groove ceiling are painted Rainwashed (soft blue-green). The trim and screen frames are painted Greek Villa. White wicker seating with cream cushions, a jute rug, a ceiling fan, potted ferns, and dappled afternoon light through the screens.",
+      [C.rainwashed, C.greekVilla],
+    ),
+    title: "Rainwashed Screened Porch — SW 6211 Soft Blue-Green",
+    description:
+      "Sherwin-Williams Rainwashed SW 6211 (LRV 59.2) on a screened-porch ceiling and walls — a soft blue-green that reads like sea glass and extends the calm of the indoors outside. A traditional painted T&G ceiling color. Greek Villa trim, white wicker, and ferns finish it. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/rainwashed-6211${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 26, key: "restock-26", theme: "soft-blue-green", format: "guest-bedroom",
+    name: "Palladian Blue Guest Bedroom",
+    image: "Palladian Blue Guest Bedroom.png",
+    prompt: buildPrompt(
+      "A serene guest bedroom. The walls are painted Palladian Blue (soft blue-green). The trim, ceiling, and a paneled headboard wall are painted Greek Villa. A linen upholstered bed, white oak nightstands, brass sconces, a wool rug, and soft morning light from a window with linen curtains.",
+      [C.palladianBlue, C.greekVilla],
+    ),
+    title: "Palladian Blue Guest Bedroom — BM HC-144 Soft Blue-Green",
+    description:
+      "Benjamin Moore Palladian Blue HC-144 (LRV 61.8) is the soft blue-green that shifts gently between blue and green with the light — a restful, welcoming guest-bedroom color. Paired with Greek Villa trim, linen, white oak, and brass. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/palladian-blue-hc-144${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 27, key: "restock-27", theme: "taupe", format: "entryway",
+    name: "Pale Taupe Entryway",
+    image: "Pale Taupe Entryway.png",
+    prompt: buildPrompt(
+      "A warm welcoming entryway. The walls are painted Pale Taupe (warm light taupe). The trim, wainscot, and a console-height bench are painted Alabaster. A round antique-brass mirror, a slim walnut console, a woven runner over wood floors, and a brass picture light. Bright daylight from a sidelight.",
+      [C.paleTaupe, C.alabaster],
+    ),
+    title: "Pale Taupe Entryway — PPG Warm Greige-Taupe",
+    description:
+      "PPG Pale Taupe 1073-3 (LRV 66.1) gives an entryway an immediate warmth — a soft greige-taupe that flatters wood floors and brass and sets a welcoming first impression. Paired with Alabaster trim and walnut. Cross-brand matches across 14 brands at PaintColorHQ.",
+    link: `${SITE}/colors/ppg/pale-taupe-1073-3${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 28, key: "restock-28", theme: "beige", format: "hallway",
+    name: "Shaker Beige Hallway",
+    image: "Shaker Beige Hallway.png",
+    prompt: buildPrompt(
+      "A bright connecting hallway. The walls are painted Shaker Beige (warm classic beige). The trim, doors, and wainscot are painted Alabaster. A runner rug over white oak floors, a row of framed black-and-white photos, a brass sconce, and natural light spilling in from a doorway at the end.",
+      [C.shakerBeige, C.alabaster],
+    ),
+    title: "Shaker Beige Hallway — BM HC-45 Warm Classic Beige",
+    description:
+      "Benjamin Moore Shaker Beige HC-45 (LRV 53.5) is the warm classic beige that makes a windowless hallway feel sunlit and inviting rather than dim. Paired with Alabaster trim and doors, white oak floors, and a gallery of framed photos. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/shaker-beige-hc-45${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 29, key: "restock-29", theme: "navy", format: "comparison",
+    name: "Best Navy Paint Colors Compared",
+    image: "Best Navy Paint Colors Compared.png",
+    prompt: buildPrompt(
+      "Three vertical wall panels side-by-side under soft, even daylight, each painted a different navy and clearly distinct from its neighbors. Left panel Hale Navy, center panel Naval, right panel Newburyport Blue. A thin white oak shelf runs across all three with a single brass candlestick.",
+      [C.haleNavy, C.naval, C.newburyportBlue],
+    ),
+    title: "Best Navy Paint Colors — Hale Navy vs Naval vs Newburyport Blue",
+    description:
+      "The three most-specified navies compared: Benjamin Moore Hale Navy HC-154 (LRV 7.1, the warm standard), Sherwin-Williams Naval SW 6244 (LRV 4.5, the deepest), and Benjamin Moore Newburyport Blue HC-155 (LRV 9, a touch more slate). Choose by depth and undertone. Full blue paint guide at PaintColorHQ.",
+    link: `${SITE}/blog/best-blue-paint-colors${UTM}`,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 30, key: "restock-30", theme: "green", format: "comparison",
+    name: "Best Green Paint Colors Compared",
+    image: "Best Green Paint Colors Compared.png",
+    prompt: buildPrompt(
+      "Three vertical wall panels side-by-side under soft, even daylight, each painted a different green and clearly distinct from its neighbors. Left panel Evergreen Fog, center panel Pewter Green, right panel Saybrook Sage. A thin white oak shelf runs across all three with a small potted fern.",
+      [C.evergreenFog, C.pewterGreen, C.saybrookSage],
+    ),
+    title: "Best Green Paint Colors — Evergreen Fog vs Pewter Green vs Saybrook Sage",
+    description:
+      "Three designer greens compared: Sherwin-Williams Evergreen Fog SW 9130 (LRV 30, soft gray-sage), Pewter Green SW 6208 (LRV 11.8, deep and moody), and Benjamin Moore Saybrook Sage HC-114 (LRV 46.4, the lightest). From whole-room calm to a dramatic island. Browse the full green collection at PaintColorHQ.",
+    link: `${SITE}/colors/family/green${UTM}`,
+    board: "Paint Color Guides",
+  },
+];

--- a/scripts/pinterest/batch-jun-restock.ts
+++ b/scripts/pinterest/batch-jun-restock.ts
@@ -1,0 +1,269 @@
+// Pinterest batch — June 2026 restock cohort (campaign: restock-jun-2026)
+// Second curated batch after may26. All color data verified against the live
+// DB (hex / RGB / LRV / undertone) on 2026-05-30; all destination slugs resolve.
+//
+// Prompts are composed by buildPrompt() so the rendering rules (single combined
+// label, no HEX char substitution, preserve LRV decimals, sans-serif) are
+// identical across every pin — see reference_gemini-image-rendering-quirks.
+
+import type { PinSpec } from "./batch-may26.ts";
+
+interface Swatch {
+  name: string;
+  hex: string;
+  rgb: string;
+  lrv: string;
+  undertone: string;
+}
+
+// --- verified color data (DB, 2026-05-30) ---
+const C = {
+  tricornBlack: { name: "Tricorn Black", hex: "#2F2F30", rgb: "47, 47, 48", lrv: "2.9", undertone: "Neutral" },
+  reposeGray: { name: "Repose Gray", hex: "#CCC9C0", rgb: "204, 201, 192", lrv: "58.4", undertone: "Neutral" },
+  urbaneBronze: { name: "Urbane Bronze", hex: "#54504A", rgb: "84, 80, 74", lrv: "8.1", undertone: "Warm Golden" },
+  pewterGreen: { name: "Pewter Green", hex: "#5E6259", rgb: "94, 98, 89", lrv: "11.8", undertone: "Warm Golden" },
+  driftOfMist: { name: "Drift of Mist", hex: "#DCD8D0", rgb: "220, 216, 208", lrv: "68.9", undertone: "Neutral" },
+  manchesterTan: { name: "Manchester Tan", hex: "#DCD3BD", rgb: "220, 211, 189", lrv: "63.2", undertone: "Neutral" },
+  cavernClay: { name: "Cavern Clay", hex: "#AC6B53", rgb: "172, 107, 83", lrv: "19.9", undertone: "Warm Golden" },
+  newburyportBlue: { name: "Newburyport Blue", hex: "#475667", rgb: "71, 86, 103", lrv: "9", undertone: "Neutral" },
+  firstLight: { name: "First Light", hex: "#F0E3DF", rgb: "240, 227, 223", lrv: "75.9", undertone: "Neutral" },
+  shojiWhite: { name: "Shoji White", hex: "#E6DFD3", rgb: "230, 223, 211", lrv: "74.3", undertone: "Neutral" },
+  crackedPepper: { name: "Cracked Pepper", hex: "#4F5152", rgb: "79, 81, 82", lrv: "8.2", undertone: "Neutral" },
+  chinesePorcelain: { name: "Chinese Porcelain", hex: "#3A5F7D", rgb: "58, 95, 125", lrv: "10.6", undertone: "Neutral" },
+  hawthorneYellow: { name: "Hawthorne Yellow", hex: "#F6E2A5", rgb: "246, 226, 165", lrv: "71.3", undertone: "Neutral" },
+  alabaster: { name: "Alabaster", hex: "#EDEAE0", rgb: "237, 234, 224", lrv: "82.2", undertone: "Neutral" },
+  greekVilla: { name: "Greek Villa", hex: "#F0ECE2", rgb: "240, 236, 226", lrv: "84", undertone: "Neutral" },
+  reverePewter: { name: "Revere Pewter", hex: "#CCC7B9", rgb: "204, 199, 185", lrv: "55.1", undertone: "Neutral" },
+  agreeableGray: { name: "Agreeable Gray", hex: "#D1CBC1", rgb: "209, 203, 193", lrv: "60", undertone: "Warm Neutral" },
+} satisfies Record<string, Swatch>;
+
+function buildPrompt(scene: string, swatches: Swatch[]): string {
+  const list = swatches
+    .map((s) => `${s.name} (HEX ${s.hex}, RGB ${s.rgb}, LRV ${s.lrv}, Undertone ${s.undertone})`)
+    .join(", ");
+  return (
+    `Vertical 2:3 pin. ${scene} ` +
+    `${swatches.length} color ${swatches.length === 1 ? "swatch overlays" : "swatches overlay"} the bottom-left corner: ${list} — ` +
+    `render EXACTLY ONE swatch label per color, no more, no less. Each label is a single rectangular block containing all of that color's data combined into one box: name (bold), HEX, RGB, LRV, and Undertone all in the same block. ` +
+    `CRITICAL: do not render Undertone in a separate label from the HEX/RGB/LRV data — all five fields belong in ONE label per color. ` +
+    `Use clean sans-serif text (Inter or Helvetica), no decorative styling. ` +
+    `Render HEX codes as exact alphanumeric strings — do not substitute D for O, B for 8, or R for K. ` +
+    `Preserve decimal points in LRV values (e.g. 7.1, not 71).`
+  );
+}
+
+const UTM = "?utm_source=Pinterest&utm_medium=organic&utm_campaign=restock-jun-2026";
+const SITE = "https://www.paintcolorhq.com";
+
+export const BATCH: PinSpec[] = [
+  {
+    id: 1, key: "restock-01", theme: "black", format: "home-office",
+    name: "Tricorn Black Home Office",
+    image: "Tricorn Black Home Office.png",
+    prompt: buildPrompt(
+      "A modern home office. The wall behind the desk is painted Tricorn Black (deep near-black). The ceiling, door, and window trim are painted Alabaster. A white oak desk with slim black legs sits against the black wall, a brass desk lamp, a leather chair, open black metal shelving with books and ceramics, a potted snake plant. Bright daylight from a window on the right.",
+      [C.tricornBlack, C.alabaster],
+    ),
+    title: "Tricorn Black Home Office — SW 6258 Near-Black Accent Wall",
+    description:
+      "Sherwin-Williams Tricorn Black SW 6258 (LRV 2.9) on a home-office accent wall with Alabaster trim, white oak, and brass. The truest near-black SW makes — no blue or green cast — so it reads as a crisp, confident backdrop for shelving and art. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/tricorn-black-6258${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 2, key: "restock-02", theme: "greige", format: "living-room",
+    name: "Repose Gray Living Room",
+    image: "Repose Gray Living Room.png",
+    prompt: buildPrompt(
+      "A bright transitional living room. The walls are painted Repose Gray (soft warm greige). The trim, ceiling, and built-ins are painted Alabaster. A cream linen sofa, walnut coffee table, woven jute rug, brass floor lamp, and a large window with linen drapes. Soft natural daylight.",
+      [C.reposeGray, C.alabaster],
+    ),
+    title: "Repose Gray Living Room — SW 7015 Warm Greige Paint Color",
+    description:
+      "Sherwin-Williams Repose Gray SW 7015 (LRV 58.4) is the warm greige that stays neutral without going cold — a reliable whole-room wall color in north- and south-facing light alike. Paired with Alabaster trim, walnut, and cream linen. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/repose-gray-7015${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 3, key: "restock-03", theme: "bronze", format: "dining-room",
+    name: "Urbane Bronze Dining Room",
+    image: "Urbane Bronze Dining Room.png",
+    prompt: buildPrompt(
+      "A moody dining room color-drenched in Urbane Bronze — the walls, trim, and ceiling are all painted Urbane Bronze (warm deep brown-gray). The adjacent ceiling line and a single doorway reveal Greek Villa as the bright contrast. A walnut pedestal table, cream linen chairs, a brass linear chandelier, and two lit taper candles. Warm evening light.",
+      [C.urbaneBronze, C.greekVilla],
+    ),
+    title: "Urbane Bronze Dining Room — SW 7048 Color-Drenched",
+    description:
+      "Sherwin-Williams Urbane Bronze SW 7048 (LRV 8.1) — the 2021 Color of the Year — color-drenched across a dining room's walls, trim, and ceiling for an enveloping, intimate effect. Its warm golden undertone keeps the deep brown-gray from feeling cold. Greek Villa as the bright relief. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/urbane-bronze-7048${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 4, key: "restock-04", theme: "green", format: "kitchen",
+    name: "Pewter Green Kitchen",
+    image: "Pewter Green Kitchen.png",
+    prompt: buildPrompt(
+      "A transitional kitchen. The lower shaker cabinets and island are painted Pewter Green (deep muted green). The upper cabinets and walls are painted Alabaster. Honed white marble countertop, unlacquered brass hardware and faucet, white oak floors, two brass pendant lights over the island. Bright morning light.",
+      [C.pewterGreen, C.alabaster],
+    ),
+    title: "Pewter Green Kitchen Cabinets — SW 6208 Deep Green",
+    description:
+      "Sherwin-Williams Pewter Green SW 6208 (LRV 11.8) on lower cabinets and island with Alabaster uppers, honed marble, and unlacquered brass. A deep green with a warm golden undertone that reads sophisticated rather than cold — the two-tone kitchen that ages well. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/pewter-green-6208${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 5, key: "restock-05", theme: "soft-gray", format: "bathroom",
+    name: "Drift of Mist Bathroom",
+    image: "Drift of Mist Bathroom.png",
+    prompt: buildPrompt(
+      "An airy bathroom. The walls are painted Drift of Mist (soft pale gray). The trim, ceiling, and vanity are painted Greek Villa. White subway tile shower, polished nickel fixtures, a round mirror, a marble-topped vanity, and eucalyptus in a glass vase. Bright even daylight.",
+      [C.driftOfMist, C.greekVilla],
+    ),
+    title: "Drift of Mist Bathroom — SW 9166 Soft Gray Paint Color",
+    description:
+      "Sherwin-Williams Drift of Mist SW 9166 (LRV 68.9) is the barely-there soft gray that keeps a bathroom feeling clean and light without going stark white. Paired with Greek Villa trim, white tile, and polished nickel. Reads neutral in the bright, even light of a windowed bath. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/drift-of-mist-9166${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 6, key: "restock-06", theme: "tan", format: "bedroom",
+    name: "Manchester Tan Bedroom",
+    image: "Manchester Tan Bedroom.png",
+    prompt: buildPrompt(
+      "A calm bedroom. The walls are painted Manchester Tan (warm light tan). The trim, ceiling, and headboard wall niche are painted Alabaster. An upholstered linen bed, white oak nightstands, brass sconces, a wool flatweave rug, and soft morning light from a left-side window.",
+      [C.manchesterTan, C.alabaster],
+    ),
+    title: "Manchester Tan Bedroom — BM HC-81 Warm Neutral",
+    description:
+      "Benjamin Moore Manchester Tan HC-81 (LRV 63.2) is the warm light tan that makes a bedroom feel restful and grounded — soft enough for walls, warm enough to flatter both linen and wood. Paired with Alabaster trim and brass. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/manchester-tan-hc-81${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 7, key: "restock-07", theme: "terracotta", format: "sunroom",
+    name: "Cavern Clay Sunroom",
+    image: "Cavern Clay Sunroom.png",
+    prompt: buildPrompt(
+      "A boho sunroom. The walls are painted Cavern Clay (warm terracotta). The trim and ceiling are painted Greek Villa. A rattan lounge chair, ivory bouclé cushions, a low travertine table, trailing pothos and a fiddle-leaf fig, a jute rug, and abundant natural light through tall windows.",
+      [C.cavernClay, C.greekVilla],
+    ),
+    title: "Cavern Clay Sunroom — SW 7701 Terracotta Paint Color",
+    description:
+      "Sherwin-Williams Cavern Clay SW 7701 (LRV 19.9) — a warm, earthy terracotta with a golden undertone — wraps a sunroom in southwestern warmth without reading orange. Paired with Greek Villa trim, rattan, travertine, and greenery. Best in the strong natural light it was made for. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/cavern-clay-7701${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 8, key: "restock-08", theme: "blue", format: "library",
+    name: "Newburyport Blue Library",
+    image: "Newburyport Blue Library.png",
+    prompt: buildPrompt(
+      "A cozy library reading nook color-drenched in Newburyport Blue — the walls and floor-to-ceiling built-in bookshelves are all painted Newburyport Blue (deep slate blue). The crown molding and window trim are painted Greek Villa. A leather wingback chair, a brass library lamp, a stack of books, and warm lamplight in the evening.",
+      [C.newburyportBlue, C.greekVilla],
+    ),
+    title: "Newburyport Blue Library — BM HC-155 Deep Slate Blue",
+    description:
+      "Benjamin Moore Newburyport Blue HC-155 (LRV 9) color-drenched across a reading nook's walls and built-in shelving creates an enveloping, library-quiet feel. A deep slate blue that anchors a room without the heaviness of black. Greek Villa trim keeps the edges crisp. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/newburyport-blue-hc-155${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 9, key: "restock-09", theme: "blush", format: "nursery",
+    name: "First Light Nursery",
+    image: "First Light Nursery.png",
+    prompt: buildPrompt(
+      "A serene nursery. The walls are painted First Light (soft blush). The trim, ceiling, and crib wall are painted Greek Villa. A blonde-wood crib, an ivory bouclé glider, a jute rug, a brass mobile, and a single eucalyptus garland above the crib. Soft morning light from a left-side window.",
+      [C.firstLight, C.greekVilla],
+    ),
+    title: "First Light Nursery — BM 2102-70 Soft Blush Paint Color",
+    description:
+      "Benjamin Moore First Light 2102-70 (LRV 75.9) — the 2020 Color of the Year — is the soft, barely-there blush that suits a gender-neutral nursery and grows with the room from baby to big-kid. Paired with Greek Villa trim, blonde wood, and brass. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/first-light-2102-70${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 10, key: "restock-10", theme: "white", format: "color-drench",
+    name: "Shoji White Entry Drench",
+    image: "Shoji White Entry Drench.png",
+    prompt: buildPrompt(
+      "A welcoming entry hall color-drenched in Shoji White — the walls, trim, ceiling, and a built-in bench are all painted Shoji White (warm soft white). The single front door is painted Urbane Bronze as the one dark contrast. Unlacquered brass hooks, a woven basket, a runner rug, and bright daylight through a sidelight window.",
+      [C.shojiWhite, C.urbaneBronze],
+    ),
+    title: "Shoji White Entryway — SW 7042 Warm White, Color-Drenched",
+    description:
+      "Sherwin-Williams Shoji White SW 7042 (LRV 74.3) color-drenched across an entry's walls, trim, and ceiling gives a soft, seamless warmth that a stark white can't. A single Urbane Bronze door adds the contrast. The warm-white that doesn't go yellow or pink in changing light. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/sherwin-williams/shoji-white-7042${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 11, key: "restock-11", theme: "black", format: "exterior",
+    name: "Cracked Pepper Exterior",
+    image: "Cracked Pepper Exterior.png",
+    prompt: buildPrompt(
+      "A modern farmhouse exterior. The board-and-batten siding is painted Alabaster. The front door, window sashes, and light fixtures are painted Cracked Pepper (soft black). A covered porch with a white oak ceiling, two black-framed lanterns, a terracotta planter with boxwood, and late-afternoon golden light.",
+      [C.crackedPepper, C.alabaster],
+    ),
+    title: "Cracked Pepper Exterior — Behr Soft Black Trim & Door",
+    description:
+      "Behr Cracked Pepper PPU18-01 (LRV 8.2) on the door, window sashes, and fixtures of an Alabaster modern-farmhouse exterior — a soft black that's deep enough to frame the house without the harshness of true black. Behr's most popular black-neutral. See cross-brand matches across 14 brands at PaintColorHQ.",
+    link: `${SITE}/colors/behr/cracked-pepper-ppu18-01${UTM}`,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 12, key: "restock-12", theme: "blue", format: "powder-room",
+    name: "Chinese Porcelain Powder Room",
+    image: "Chinese Porcelain Powder Room.png",
+    prompt: buildPrompt(
+      "A dramatic powder room color-drenched in Chinese Porcelain — the walls and ceiling are painted Chinese Porcelain (deep porcelain blue). The trim and wainscot cap are painted Greek Villa. A floating walnut vanity, an unlacquered brass faucet and sconces, a round brass mirror, and warm focused lighting.",
+      [C.chinesePorcelain, C.greekVilla],
+    ),
+    title: "Chinese Porcelain Powder Room — PPG 1160-6 Deep Blue",
+    description:
+      "PPG Chinese Porcelain 1160-6 (LRV 10.6) — the 2020 PPG Color of the Year — color-drenched in a small powder room is the classic place to be bold: a deep porcelain blue that turns a windowless half-bath into the most memorable room in the house. Greek Villa trim, walnut, and brass. Cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/ppg/chinese-porcelain-1160-6${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 13, key: "restock-13", theme: "yellow", format: "breakfast-nook",
+    name: "Hawthorne Yellow Breakfast Nook",
+    image: "Hawthorne Yellow Breakfast Nook.png",
+    prompt: buildPrompt(
+      "A cheerful breakfast nook. The walls are painted Hawthorne Yellow (warm buttery yellow). The trim, built-in bench, and ceiling are painted Alabaster. A round white oak table, a cushioned banquette with striped pillows, a brass pendant, a vase of fresh greens, and bright morning sun through a bay window.",
+      [C.hawthorneYellow, C.alabaster],
+    ),
+    title: "Hawthorne Yellow Breakfast Nook — BM HC-4 Warm Yellow",
+    description:
+      "Benjamin Moore Hawthorne Yellow HC-4 (LRV 71.3) is the warm, buttery yellow that makes a breakfast nook feel sunny even on gray mornings — historic and cheerful without going neon. Paired with Alabaster trim, white oak, and brass. Full cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/benjamin-moore/hawthorne-yellow-hc-4${UTM}`,
+    board: "Color Palettes",
+  },
+  {
+    id: 14, key: "restock-14", theme: "white", format: "comparison",
+    name: "Best Warm Whites Compared",
+    image: "Best Warm Whites Compared.png",
+    prompt: buildPrompt(
+      "Three vertical wall panels side-by-side under soft, even north-facing daylight, each painted a different warm white and clearly distinct from its neighbors. Left panel Alabaster, center panel Greek Villa, right panel Shoji White. A thin white oak shelf runs across all three with a single ceramic vase.",
+      [C.alabaster, C.greekVilla, C.shojiWhite],
+    ),
+    title: "Best Warm White Paint Colors — Alabaster vs Greek Villa vs Shoji White",
+    description:
+      "The three most-specified Sherwin-Williams warm whites side-by-side: Alabaster (LRV 82.2, soft warm white), Greek Villa (LRV 84, the brightest), and Shoji White (LRV 74.3, the warmest, with the most depth). Choose by how much warmth and softness you want. Full white paint guide at PaintColorHQ.",
+    link: `${SITE}/blog/best-white-paint-colors-guide${UTM}`,
+    board: "Paint Color Guides",
+  },
+  {
+    id: 15, key: "restock-15", theme: "greige", format: "comparison",
+    name: "Best Greiges Compared",
+    image: "Best Greiges Compared.png",
+    prompt: buildPrompt(
+      "Three vertical wall panels side-by-side under soft, even daylight, each painted a different greige and clearly distinct from its neighbors. Left panel Agreeable Gray, center panel Repose Gray, right panel Revere Pewter. A thin white oak shelf runs across all three with a small stack of books.",
+      [C.agreeableGray, C.reposeGray, C.reverePewter],
+    ),
+    title: "Best Greige Paint Colors — Agreeable Gray vs Repose Gray vs Revere Pewter",
+    description:
+      "The three most-searched greiges compared: Sherwin-Williams Agreeable Gray (LRV 60, the balanced standard), Repose Gray (LRV 58.4, a touch cooler), and Benjamin Moore Revere Pewter (LRV 55.1, the warmest and deepest). The whole-house neutrals designers reach for. Browse the full gray & greige collection with cross-brand matches at PaintColorHQ.",
+    link: `${SITE}/colors/family/gray${UTM}`,
+    board: "Paint Color Guides",
+  },
+];

--- a/scripts/pinterest/batch-jun-restock.ts
+++ b/scripts/pinterest/batch-jun-restock.ts
@@ -8,7 +8,7 @@
 
 import type { PinSpec } from "./batch-may26.ts";
 
-interface Swatch {
+export interface Swatch {
   name: string;
   hex: string;
   rgb: string;
@@ -37,7 +37,7 @@ const C = {
   agreeableGray: { name: "Agreeable Gray", hex: "#D1CBC1", rgb: "209, 203, 193", lrv: "60", undertone: "Warm Neutral" },
 } satisfies Record<string, Swatch>;
 
-function buildPrompt(scene: string, swatches: Swatch[]): string {
+export function buildPrompt(scene: string, swatches: Swatch[]): string {
   const list = swatches
     .map((s) => `${s.name} (HEX ${s.hex}, RGB ${s.rgb}, LRV ${s.lrv}, Undertone ${s.undertone})`)
     .join(", ");

--- a/scripts/pinterest/queue.ts
+++ b/scripts/pinterest/queue.ts
@@ -2,12 +2,13 @@
 // Pure functions only — no I/O — so the drip logic is unit-testable.
 
 import { BATCH as MAY26 } from "./batch-may26.ts";
+import { BATCH as JUN_RESTOCK } from "./batch-jun-restock.ts";
 export { BOARD_IDS, IMAGE_DIR } from "./batch-may26.ts";
 export type { PinSpec, BoardName } from "./batch-may26.ts";
 import type { PinSpec } from "./batch-may26.ts";
 
 /** All approved batches, concatenated in intended publish order. */
-export const QUEUE: PinSpec[] = [...MAY26];
+export const QUEUE: PinSpec[] = [...MAY26, ...JUN_RESTOCK];
 
 export type PublishedLog = Record<string, { pinId: string; publishedAt: string }>;
 

--- a/scripts/pinterest/queue.ts
+++ b/scripts/pinterest/queue.ts
@@ -3,12 +3,13 @@
 
 import { BATCH as MAY26 } from "./batch-may26.ts";
 import { BATCH as JUN_RESTOCK } from "./batch-jun-restock.ts";
+import { BATCH as JUN_RESTOCK_2 } from "./batch-jun-restock-2.ts";
 export { BOARD_IDS, IMAGE_DIR } from "./batch-may26.ts";
 export type { PinSpec, BoardName } from "./batch-may26.ts";
 import type { PinSpec } from "./batch-may26.ts";
 
 /** All approved batches, concatenated in intended publish order. */
-export const QUEUE: PinSpec[] = [...MAY26, ...JUN_RESTOCK];
+export const QUEUE: PinSpec[] = [...MAY26, ...JUN_RESTOCK, ...JUN_RESTOCK_2];
 
 export type PublishedLog = Record<string, { pinId: string; publishedAt: string }>;
 


### PR DESCRIPTION
## What

Refills the drip queue (empty after may26 went live) with **30 curated pins** across two batches, campaign `restock-jun-2026`.

- **30 pins**, ~26 distinct room formats, **6 brands** (SW, BM, Behr, Valspar, PPG, Dunn-Edwards).
- All color data (hex / RGB / LRV / undertone) **verified against the live DB**; all 30 destination URLs return 200. 3 cross-brand picks were swapped to in-DB colors after the accuracy gate (Behr Swiss Coffee, DE Bay Fog, PPG Pale Taupe).
- Generated via `gemini-3-pro-image` and **QA'd swatch-by-swatch** — zero rendering errors across all 30.

## Changes
- `scripts/pinterest/batch-jun-restock.ts` — batch 1 (restock-01..15); exports shared `buildPrompt`/`Swatch`.
- `scripts/pinterest/batch-jun-restock-2.ts` — batch 2 (restock-16..30).
- `scripts/pinterest/queue.ts` — aggregates may26 + both restock batches → `QUEUE` (40 total).
- `scripts/pinterest-generate.ts` — reads the full `QUEUE`, skips existing images (keys, not ids).

## State
- Queue: **40 total, 30 unpublished** — a deep, varied backlog for the drip's variety rotation.
- Images in `~/Desktop/Pinterest pins/` (not committed, same as may26).
- `npm run test:pinterest` → 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)