### PR TITLE
Scheduled blog publishing (future-dated posts)

### DIFF
--- a/docs/superpowers/content/blog-pipeline-runbook.md
+++ b/docs/superpowers/content/blog-pipeline-runbook.md
@@ -73,6 +73,10 @@ auto-appears in the sitemap, related-posts, and the Pinterest **guide** drip lan
 - Philip reviews **voice / usefulness / topic fit / images** — NOT paint facts
   (those are verified in Stage 3).
 - Merge → post is live + becomes a Pinterest guide pin on the next drip.
+- **Scheduling:** set the post's `date` to a future day to pre-stock it. It stays
+  hidden from the live site, sitemap, and the pin drip until that date, then
+  reveals itself (within ~1h, via ISR) — no second merge needed. Reviewable on the
+  PR's Vercel preview by URL even while scheduled. See `src/lib/blog-publish.ts`.
 
 ---
 

--- a/scripts/blog/blog-publish.test.ts
+++ b/scripts/blog/blog-publish.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isLiveAt, canRenderAt } from "../../src/lib/blog-publish.ts";
+
+const NOW = new Date("2026-06-01T12:00:00Z");
+
+test("isLiveAt: a past or today date is live", () => {
+  assert.equal(isLiveAt("2026-05-31", NOW), true);
+  assert.equal(isLiveAt("2026-06-01", NOW), true); // earlier today (UTC midnight) <= now
+});
+
+test("isLiveAt: a future date is not live", () => {
+  assert.equal(isLiveAt("2026-06-07", NOW), false);
+});
+
+test("canRenderAt: live posts render in production", () => {
+  assert.equal(canRenderAt("2026-05-31", NOW, true), true);
+});
+
+test("canRenderAt: future post is hidden in production but viewable on preview/dev", () => {
+  assert.equal(canRenderAt("2026-06-07", NOW, true), false); // production hides it
+  assert.equal(canRenderAt("2026-06-07", NOW, false), true); // preview/dev shows it for review
+});

--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -4,6 +4,9 @@ import { getAllBlogSlugs, getPostBySlug } from "@/lib/blog-posts";
 import { inspirationPalettes } from "@/lib/palettes";
 import { POPULAR_COLOR_SLUGS, MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
 
+// ISR: refresh hourly so a scheduled post enters its sitemap shard on its date.
+export const revalidate = 3600;
+
 const BASE_URL = "https://www.paintcolorhq.com";
 const COLORS_PER_SITEMAP = 5000;
 

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { getAllColorSlugs } from "@/lib/queries";
 import { getAllBlogSlugs } from "@/lib/blog-posts";
 
+// ISR: refresh hourly so a scheduled post enters the sitemap index on its date.
+export const revalidate = 3600;
+
 const BASE_URL = "https://www.paintcolorhq.com";
 const COLORS_PER_SITEMAP = 5000;
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,6 +11,11 @@ import { TableOfContents } from "@/components/table-of-contents";
 import { ColorLinkEnhancer } from "@/components/color-link-enhancer";
 import { PinterestSaveButton } from "@/components/pinterest-save-button";
 
+// ISR: re-render hourly so a scheduled post becomes reachable on its date
+// (and 404s before it). dynamicParams (default true) renders not-yet-prebuilt
+// slugs on demand once they go live. See src/lib/blog-publish.ts.
+export const revalidate = 3600;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,6 +7,10 @@ import { AdSenseScript } from "@/components/adsense-script";
 import { getAllPosts } from "@/lib/blog-posts";
 import { TagFilter } from "@/components/tag-filter";
 
+// ISR: re-render hourly so scheduled (future-dated) posts appear on their date
+// without a redeploy. See src/lib/blog-publish.ts.
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: "Paint Color Blog — Guides, Trends & Color Theory",
   description:

--- a/src/lib/blog-posts.tsx
+++ b/src/lib/blog-posts.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import Link from "next/link";
+import { isLive, canRender } from "./blog-publish";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -3538,24 +3539,27 @@ const blogPosts: BlogPost[] = [
 /*  Exports                                                            */
 /* ------------------------------------------------------------------ */
 
-/** All posts, newest first */
+/** All published posts, newest first. Excludes future-dated (scheduled) posts. */
 export function getAllPosts(): BlogPost[] {
-  return [...blogPosts].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
+  return [...blogPosts]
+    .filter((p) => isLive(p.date))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
-/** Single post by slug */
+/** Single post by slug. Scheduled (future-dated) posts return undefined on
+ *  production — so the page 404s — but render on preview/dev for review. */
 export function getPostBySlug(slug: string): BlogPost | undefined {
-  return blogPosts.find((p) => p.slug === slug);
+  const post = blogPosts.find((p) => p.slug === slug);
+  return post && canRender(post.date) ? post : undefined;
 }
 
-/** All slugs — for generateStaticParams and sitemap. Excludes noindexed posts. */
+/** All slugs — for generateStaticParams and sitemap. Excludes noindexed and
+ *  not-yet-published (future-dated) posts. */
 export function getAllBlogSlugs(): string[] {
-  return blogPosts.filter((p) => !p.noindex).map((p) => p.slug);
+  return blogPosts.filter((p) => !p.noindex && isLive(p.date)).map((p) => p.slug);
 }
 
-/** Related posts: same-tag posts excluding the current one, newest first */
+/** Related posts: same-tag published posts excluding the current one, newest first */
 export function getRelatedPosts(slug: string, limit = 3): BlogPost[] {
   const current = blogPosts.find((p) => p.slug === slug);
   if (!current) return [];
@@ -3564,7 +3568,7 @@ export function getRelatedPosts(slug: string, limit = 3): BlogPost[] {
 
   // Score each post by number of shared tags
   const scored = blogPosts
-    .filter((p) => p.slug !== slug)
+    .filter((p) => p.slug !== slug && isLive(p.date))
     .map((p) => ({
       post: p,
       shared: p.tags.filter((t) => currentTags.has(t)).length,
@@ -3591,6 +3595,7 @@ export function getPostsByBrand(brandName: string, limit = 3): BlogPost[] {
   const terms = [lower, ...(aliases[lower] ?? [])];
 
   const matches = blogPosts.filter((p) => {
+    if (!isLive(p.date)) return false;
     const searchable = `${p.title} ${p.excerpt} ${p.tags.join(" ")}`.toLowerCase();
     return terms.some((t) => searchable.includes(t));
   });

--- a/src/lib/blog-publish.ts
+++ b/src/lib/blog-publish.ts
@@ -1,0 +1,35 @@
+/**
+ * Scheduled-publishing gate for blog posts. Pure logic, no JSX — so it can be
+ * unit-tested and imported by both the app and the Pinterest scripts.
+ *
+ * Model: a post's `date` IS its publish date. A future date = scheduled; the
+ * post is committed to main but stays hidden until the date arrives.
+ *
+ * Two gates:
+ *  - isLive: strict date check. Used for every list, the sitemap, related/brand
+ *    posts, and the Pinterest drip — so a scheduled post never leaks into a feed
+ *    or gets pinned before it's live, regardless of where the code runs.
+ *  - canRender: governs whether a single post PAGE may render. Live posts always;
+ *    not-yet-live posts render only on non-production deploys (Vercel preview /
+ *    local dev) so they can be reviewed before going live.
+ */
+
+/** True when the post's date has arrived (compared at the given instant). */
+export function isLiveAt(dateStr: string, now: Date): boolean {
+  return new Date(dateStr).getTime() <= now.getTime();
+}
+
+/** Strict live check against the real clock. */
+export function isLive(dateStr: string): boolean {
+  return isLiveAt(dateStr, new Date());
+}
+
+/** Whether a post page may render: live always; scheduled only off-production. */
+export function canRenderAt(dateStr: string, now: Date, isProduction: boolean): boolean {
+  return isLiveAt(dateStr, now) || !isProduction;
+}
+
+/** canRender against the real clock + the current Vercel environment. */
+export function canRender(dateStr: string): boolean {
+  return canRenderAt(dateStr, new Date(), process.env.VERCEL_ENV === "production");
+}


### PR DESCRIPTION
Lets us **pre-stock blog posts in main** and have them appear on their own publish date — no second merge, no unattended auto-publish, no same-day burst risk.

## How it works
A post's `date` is its publish date. Set it in the future, merge whenever review is done, and the post stays hidden until that day, then reveals itself.

- **`src/lib/blog-publish.ts`** (pure, unit-tested): `isLive` = strict date check; `canRender` = live OR non-production.
- **`blog-posts.tsx`** wiring:
  - `getAllPosts` / `getAllBlogSlugs` / `getRelatedPosts` / `getPostsByBrand` → **strict date gate**. A scheduled post never appears in a list, the **sitemap**, or — importantly — the **Pinterest drip** (which reads `getAllPosts`), regardless of where the code runs.
  - `getPostBySlug` → **`canRender`**: a scheduled post **404s on production** but **renders on Vercel preview / local dev**, so you can review it by URL before it's live.
- **ISR `revalidate = 3600`** added to `/blog`, `/blog/[slug]`, and both sitemap routes — they were fully static (frozen at build), so without this a scheduled post would never auto-reveal. Now it appears within ~1h of its date.

## Design note (changed from first sketch)
I'd originally said "preview shows everything." That can't live in `getAllPosts`, because the **local pin drip** reads it and `VERCEL_ENV` isn't `production` locally — it would have pinned unpublished posts. So the preview bypass is contained to `getPostBySlug` only; everything feed-like uses the strict date gate.

## Caveats (documented in the runbook)
- Reveal is ISR-bounded (~within 1h of the date on first request after the TTL), not minute-precise — fine for blogs.
- `"YYYY-MM-DD"` publishes at UTC midnight (≈7–8pm ET the night before).

## Test Plan
- [x] `npm run test:blog` → 13/13 (4 new gate tests)
- [x] tsc: no type errors in source files
- [x] eslint: 0 errors
- [x] integration check: 30 posts intact (no over-filter); future date → hidden from feeds, viewable on preview
- [ ] Preview: existing posts render normally; a temp future-dated post 404s on prod-like build but shows on preview

## Usage after merge
Set a post's `date` to the day you want it live, merge, done. Pacing happens by dates, not by holding PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)