### PR TITLE
Pinterest analytics-by-type (local reach view)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ scripts/drift/*.db-wal
 # Pinterest runtime state (pin IDs + drip log; not secrets, but runtime-only)
 scripts/pinterest/published*.json
 scripts/pinterest/drip.log
+scripts/pinterest/analytics.log
+scripts/pinterest/reports/

--- a/scripts/pinterest/analytics-by-type.ts
+++ b/scripts/pinterest/analytics-by-type.ts
@@ -16,10 +16,10 @@
  *   npx tsx scripts/pinterest/analytics-by-type.ts --start=2026-05-27 --end=2026-06-02
  *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7 --email   # also email via Resend
  *
- * --email sends the report through Resend IF RESEND_API_KEY is set in .env.local
- * (to REPORT_EMAIL_TO, default philip@theorphanshands.org). If the key is absent
- * it prints a notice and skips — the report still prints/returns for the caller
- * (the launchd wrapper writes it to a file + macOS notification regardless).
+ * --email sends a styled HTML report through Resend IF RESEND_API_KEY is set in
+ * .env.local (to REPORT_EMAIL_TO, default philip@theorphanshands.org). If the key
+ * is absent it prints a notice and skips — the plain-text report still prints for
+ * the launchd wrapper, which writes it to a file + macOS notification regardless.
  */
 import "../blog/load-env.ts"; // loads .env.local before anything reads process.env
 import * as path from "path";
@@ -37,6 +37,14 @@ let accessToken = process.env.PINTEREST_ACCESS_TOKEN!;
 
 const METRICS = ["IMPRESSION", "PIN_CLICK", "OUTBOUND_CLICK", "SAVE"] as const;
 type Metric = (typeof METRICS)[number];
+
+/** Friendly labels for the pin types stored in the queue. */
+const TYPE_LABEL: Record<string, string> = {
+  swatch: "Swatch",
+  guide: "Guide / blog",
+  palette: "Room scene",
+  comparison: "Comparison",
+};
 
 const args = process.argv.slice(2);
 const EMAIL = args.includes("--email");
@@ -100,8 +108,88 @@ async function pinSummary(pinId: string, start: string, end: string): Promise<Re
   return out;
 }
 
-/** Email the report via Resend (same provider the site uses). No-op if no key. */
-async function emailReport(body: string, window: string): Promise<string> {
+interface Agg { pins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number }
+interface Row extends Agg { type: string }
+
+const num = (n: number) => n.toLocaleString("en-US");
+const rate = (a: Agg) => (a.IMPRESSION ? ((a.OUTBOUND_CLICK / a.IMPRESSION) * 100).toFixed(2) : "0.00") + "%";
+
+/** Plain-text table — for the terminal and the saved report file. */
+function buildText(rows: Row[], tot: Agg, start: string, end: string, pinCount: number): string {
+  const L: string[] = [];
+  const pad = (v: string | number, n: number) => String(v).padStart(n);
+  L.push(`Pinterest reach by pin type — ${start} → ${end} (${pinCount} drip pins)`);
+  L.push("");
+  L.push(`${"type".padEnd(13)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
+  L.push("-".repeat(57));
+  for (const r of rows) {
+    L.push(`${(TYPE_LABEL[r.type] ?? r.type).padEnd(13)}${pad(r.pins, 5)}${pad(r.IMPRESSION, 8)}${pad(r.PIN_CLICK, 8)}${pad(r.OUTBOUND_CLICK, 8)}${pad(r.SAVE, 7)}${pad(rate(r), 8)}`);
+  }
+  L.push("-".repeat(57));
+  L.push(`${"TOTAL".padEnd(13)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(rate(tot), 8)}`);
+  L.push("");
+  L.push(`out% = outbound clicks ÷ impressions — the click-through-to-site rate (the lever to optimize).`);
+  L.push(`Note: the drip's own pins only; account-wide reach also includes older/manual pins.`);
+  return L.join("\n");
+}
+
+/** Styled HTML table — inline CSS only (email clients strip <style>). */
+function buildHtml(rows: Row[], tot: Agg, start: string, end: string, pinCount: number): string {
+  const wrap = "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1a1a1a;";
+  const th = "padding:8px 12px;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#ffffff;background:#2b2b2b;text-align:right;";
+  const thL = th.replace("text-align:right;", "text-align:left;");
+  const td = "padding:8px 12px;font-size:14px;text-align:right;border-bottom:1px solid #ececec;font-variant-numeric:tabular-nums;";
+  const tdL = td.replace("text-align:right;", "text-align:left;font-weight:600;");
+  const cell = (r: Row | Agg, key: Metric) => `<td style="${td}">${num(r[key])}</td>`;
+
+  const bodyRows = rows
+    .map((r, i) => {
+      const bg = i % 2 ? "background:#fafafa;" : "";
+      const label = TYPE_LABEL[r.type] ?? r.type;
+      return `<tr style="${bg}">
+        <td style="${tdL}${bg}">${label}</td>
+        <td style="${td}${bg}">${num(r.pins)}</td>
+        ${cell(r, "IMPRESSION")}${cell(r, "PIN_CLICK")}${cell(r, "OUTBOUND_CLICK")}${cell(r, "SAVE")}
+        <td style="${td}${bg}font-weight:600;color:#0a66c2;">${rate(r)}</td>
+      </tr>`;
+    })
+    .join("");
+
+  const totRow = `<tr>
+    <td style="${tdL}border-top:2px solid #2b2b2b;border-bottom:none;">Total</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.pins)}</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.IMPRESSION)}</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.PIN_CLICK)}</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.OUTBOUND_CLICK)}</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.SAVE)}</td>
+    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;color:#0a66c2;">${rate(tot)}</td>
+  </tr>`;
+
+  return `<div style="${wrap}max-width:640px;margin:0 auto;padding:8px 4px;">
+    <h2 style="font-size:18px;margin:0 0 2px;">Pinterest reach by pin type</h2>
+    <p style="margin:0 0 16px;color:#666;font-size:13px;">${start} → ${end} · ${pinCount} drip pins</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;width:100%;border:1px solid #ececec;border-radius:8px;overflow:hidden;">
+      <thead><tr>
+        <th style="${thL}">Pin type</th>
+        <th style="${th}">Pins</th>
+        <th style="${th}">Impressions</th>
+        <th style="${th}">Pin clicks</th>
+        <th style="${th}">Outbound</th>
+        <th style="${th}">Saves</th>
+        <th style="${th}">Out&nbsp;rate</th>
+      </tr></thead>
+      <tbody>${bodyRows}${totRow}</tbody>
+    </table>
+    <p style="margin:16px 0 4px;color:#666;font-size:12px;line-height:1.5;">
+      <strong>Out rate</strong> = outbound clicks ÷ impressions — the click-through-to-site rate, the lever to optimize.
+    </p>
+    <p style="margin:0;color:#999;font-size:12px;line-height:1.5;">
+      The drip's own pins only; account-wide reach also includes older/manual pins. PaintColorHQ weekly.
+    </p>
+  </div>`;
+}
+
+async function emailReport(text: string, html: string, window: string): Promise<string> {
   const key = process.env.RESEND_API_KEY;
   const to = process.env.REPORT_EMAIL_TO || "philip@theorphanshands.org";
   if (!key) return "✉️  skipped email — no RESEND_API_KEY in .env.local (report saved + notified instead).";
@@ -112,7 +200,8 @@ async function emailReport(body: string, window: string): Promise<string> {
       from: "Paint Color HQ <delivered@resend.dev>",
       to,
       subject: `PaintColorHQ — Pinterest reach by pin type (${window})`,
-      text: body,
+      html,
+      text,
     }),
   });
   if (!res.ok) return `✉️  email failed (${res.status}): ${(await res.text()).slice(0, 160)}`;
@@ -123,7 +212,7 @@ async function main() {
   const start = arg("start") ?? daysAgo(arg("days") ? Number(arg("days")) : 30);
   const end = arg("end") ?? daysAgo(1); // yesterday — today isn't finalized
 
-  const keyToType = new Map<string, string>(QUEUE.map((p) => [p.key, p.type]));
+  const keyToType = new Map<string, string>(QUEUE.map((p) => [p.key, p.type] as [string, string]));
   const published: Record<string, { pinId?: string; publishedAt?: string }> = JSON.parse(
     fs.readFileSync(PUBLISHED_PATH, "utf8"),
   );
@@ -131,7 +220,6 @@ async function main() {
     .filter(([, v]) => v.pinId)
     .map(([key, v]) => ({ key, pinId: v.pinId!, type: keyToType.get(key) ?? key.split(/[-_]/)[0] }));
 
-  type Agg = { pins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number };
   const byType = new Map<string, Agg>();
   let failures = 0;
   for (const pin of pins) {
@@ -148,35 +236,18 @@ async function main() {
     byType.set(pin.type, a);
   }
 
-  // Build the report (returned as text so the caller can email/file it).
-  const L: string[] = [];
-  const pad = (v: string | number, n: number) => String(v).padStart(n);
-  L.push(`Pinterest analytics by pin type — ${start} → ${end} (${pins.length} drip pins)`);
-  L.push("");
-  L.push(`${"type".padEnd(12)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
-  L.push("-".repeat(56));
-  const rows = [...byType.entries()].sort((x, y) => y[1].IMPRESSION - x[1].IMPRESSION);
+  const rows: Row[] = [...byType.entries()]
+    .map(([type, a]) => ({ type, ...a }))
+    .sort((x, y) => y.IMPRESSION - x.IMPRESSION);
   const tot: Agg = { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
-  for (const [type, a] of rows) {
-    const outRate = a.IMPRESSION ? ((a.OUTBOUND_CLICK / a.IMPRESSION) * 100).toFixed(2) : "0.00";
-    L.push(`${type.padEnd(12)}${pad(a.pins, 5)}${pad(a.IMPRESSION, 8)}${pad(a.PIN_CLICK, 8)}${pad(a.OUTBOUND_CLICK, 8)}${pad(a.SAVE, 7)}${pad(outRate + "%", 8)}`);
-    tot.pins += a.pins;
-    for (const m of METRICS) tot[m] += a[m];
-  }
-  L.push("-".repeat(56));
-  const totRate = tot.IMPRESSION ? ((tot.OUTBOUND_CLICK / tot.IMPRESSION) * 100).toFixed(2) : "0.00";
-  L.push(`${"TOTAL".padEnd(12)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(totRate + "%", 8)}`);
-  if (failures) L.push(`\n${failures} pin(s) had no analytics yet (new pins).`);
-  L.push("");
-  L.push(`out% = outbound clicks ÷ impressions — the click-through-to-site rate (the lever to optimize).`);
-  L.push(`Note: these are the drip's own pins only; account-wide reach includes older/manual pins.`);
+  for (const r of rows) { tot.pins += r.pins; for (const m of METRICS) tot[m] += r[m]; }
 
-  const report = L.join("\n");
-  console.log(report);
+  const text = buildText(rows, tot, start, end, pins.length) + (failures ? `\n(${failures} pin(s) had no analytics yet.)` : "");
+  console.log(text);
 
   if (EMAIL) {
-    const status = await emailReport(report, `${start} → ${end}`);
-    console.log("\n" + status);
+    const html = buildHtml(rows, tot, start, end, pins.length);
+    console.log("\n" + (await emailReport(text, html, `${start} → ${end}`)));
   }
 }
 

--- a/scripts/pinterest/analytics-by-type.ts
+++ b/scripts/pinterest/analytics-by-type.ts
@@ -96,6 +96,7 @@ async function refreshAccessToken(): Promise<void> {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pinterest JSON shapes vary by endpoint
 async function pinterest(pathname: string, retry = true): Promise<any> {
   const res = await fetch(`${API}${pathname}`, { headers: { Authorization: `Bearer ${accessToken}` } });
   // Rate limited — wait (honor Retry-After) and retry a few times.

--- a/scripts/pinterest/analytics-by-type.ts
+++ b/scripts/pinterest/analytics-by-type.ts
@@ -11,9 +11,15 @@
  * outbound clicks, so the drip's daily mix can shift toward the winner.
  *
  * Usage:
- *   npx tsx scripts/pinterest/analytics-by-type.ts            # last 30 days
+ *   npx tsx scripts/pinterest/analytics-by-type.ts            # last 30 days → stdout
  *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7
  *   npx tsx scripts/pinterest/analytics-by-type.ts --start=2026-05-27 --end=2026-06-02
+ *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7 --email   # also email via Resend
+ *
+ * --email sends the report through Resend IF RESEND_API_KEY is set in .env.local
+ * (to REPORT_EMAIL_TO, default philip@theorphanshands.org). If the key is absent
+ * it prints a notice and skips — the report still prints/returns for the caller
+ * (the launchd wrapper writes it to a file + macOS notification regardless).
  */
 import "../blog/load-env.ts"; // loads .env.local before anything reads process.env
 import * as path from "path";
@@ -32,11 +38,12 @@ let accessToken = process.env.PINTEREST_ACCESS_TOKEN!;
 const METRICS = ["IMPRESSION", "PIN_CLICK", "OUTBOUND_CLICK", "SAVE"] as const;
 type Metric = (typeof METRICS)[number];
 
+const args = process.argv.slice(2);
+const EMAIL = args.includes("--email");
 function arg(name: string): string | undefined {
-  return process.argv.slice(2).find((a) => a.startsWith(`--${name}=`))?.replace(`--${name}=`, "");
+  return args.find((a) => a.startsWith(`--${name}=`))?.replace(`--${name}=`, "");
 }
 
-/** YYYY-MM-DD, n days before today (UTC). */
 function daysAgo(n: number): string {
   const d = new Date();
   d.setUTCDate(d.getUTCDate() - n);
@@ -69,7 +76,6 @@ async function refreshAccessToken(): Promise<void> {
   const updates: Record<string, string> = { PINTEREST_ACCESS_TOKEN: data.access_token };
   if (data.refresh_token) updates.PINTEREST_REFRESH_TOKEN = data.refresh_token;
   upsertEnv(updates);
-  console.log("   ↻ refreshed access token");
 }
 
 async function pinterest(pathname: string, retry = true): Promise<any> {
@@ -84,11 +90,9 @@ async function pinterest(pathname: string, retry = true): Promise<any> {
   return data;
 }
 
-/** Sum a single pin's summary metrics over the window. Returns zeros on failure. */
 async function pinSummary(pinId: string, start: string, end: string): Promise<Record<Metric, number>> {
   const q = `start_date=${start}&end_date=${end}&metric_types=${METRICS.join(",")}`;
   const data = await pinterest(`/pins/${pinId}/analytics?${q}`);
-  // Pinterest shape: { all: { summary_metrics: {IMPRESSION: n, ...}, daily_metrics: [...] } }
   const all = data.all ?? data;
   const summary = all.summary_metrics ?? {};
   const out = {} as Record<Metric, number>;
@@ -96,12 +100,30 @@ async function pinSummary(pinId: string, start: string, end: string): Promise<Re
   return out;
 }
 
+/** Email the report via Resend (same provider the site uses). No-op if no key. */
+async function emailReport(body: string, window: string): Promise<string> {
+  const key = process.env.RESEND_API_KEY;
+  const to = process.env.REPORT_EMAIL_TO || "philip@theorphanshands.org";
+  if (!key) return "✉️  skipped email — no RESEND_API_KEY in .env.local (report saved + notified instead).";
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from: "Paint Color HQ <delivered@resend.dev>",
+      to,
+      subject: `PaintColorHQ — Pinterest reach by pin type (${window})`,
+      text: body,
+    }),
+  });
+  if (!res.ok) return `✉️  email failed (${res.status}): ${(await res.text()).slice(0, 160)}`;
+  return `✉️  emailed to ${to}`;
+}
+
 async function main() {
   const start = arg("start") ?? daysAgo(arg("days") ? Number(arg("days")) : 30);
   const end = arg("end") ?? daysAgo(1); // yesterday — today isn't finalized
 
   const keyToType = new Map<string, string>(QUEUE.map((p) => [p.key, p.type]));
-
   const published: Record<string, { pinId?: string; publishedAt?: string }> = JSON.parse(
     fs.readFileSync(PUBLISHED_PATH, "utf8"),
   );
@@ -109,19 +131,15 @@ async function main() {
     .filter(([, v]) => v.pinId)
     .map(([key, v]) => ({ key, pinId: v.pinId!, type: keyToType.get(key) ?? key.split(/[-_]/)[0] }));
 
-  console.log(`Pinterest analytics by type — ${start} → ${end} (${pins.length} published pins)\n`);
-
   type Agg = { pins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number };
   const byType = new Map<string, Agg>();
   let failures = 0;
-
   for (const pin of pins) {
     let s: Record<Metric, number>;
     try {
       s = await pinSummary(pin.pinId, start, end);
-    } catch (e) {
+    } catch {
       failures++;
-      console.error(`  ⚠️  ${pin.key} (${pin.pinId}): ${e instanceof Error ? e.message : e}`);
       continue;
     }
     const a = byType.get(pin.type) ?? { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
@@ -130,21 +148,36 @@ async function main() {
     byType.set(pin.type, a);
   }
 
-  const rows = [...byType.entries()].sort((x, y) => y[1].IMPRESSION - x[1].IMPRESSION);
+  // Build the report (returned as text so the caller can email/file it).
+  const L: string[] = [];
   const pad = (v: string | number, n: number) => String(v).padStart(n);
-  console.log(`${"type".padEnd(12)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
-  console.log("-".repeat(56));
+  L.push(`Pinterest analytics by pin type — ${start} → ${end} (${pins.length} drip pins)`);
+  L.push("");
+  L.push(`${"type".padEnd(12)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
+  L.push("-".repeat(56));
+  const rows = [...byType.entries()].sort((x, y) => y[1].IMPRESSION - x[1].IMPRESSION);
   const tot: Agg = { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
   for (const [type, a] of rows) {
     const outRate = a.IMPRESSION ? ((a.OUTBOUND_CLICK / a.IMPRESSION) * 100).toFixed(2) : "0.00";
-    console.log(`${type.padEnd(12)}${pad(a.pins, 5)}${pad(a.IMPRESSION, 8)}${pad(a.PIN_CLICK, 8)}${pad(a.OUTBOUND_CLICK, 8)}${pad(a.SAVE, 7)}${pad(outRate + "%", 8)}`);
-    tot.pins += a.pins; for (const m of METRICS) tot[m] += a[m];
+    L.push(`${type.padEnd(12)}${pad(a.pins, 5)}${pad(a.IMPRESSION, 8)}${pad(a.PIN_CLICK, 8)}${pad(a.OUTBOUND_CLICK, 8)}${pad(a.SAVE, 7)}${pad(outRate + "%", 8)}`);
+    tot.pins += a.pins;
+    for (const m of METRICS) tot[m] += a[m];
   }
-  console.log("-".repeat(56));
+  L.push("-".repeat(56));
   const totRate = tot.IMPRESSION ? ((tot.OUTBOUND_CLICK / tot.IMPRESSION) * 100).toFixed(2) : "0.00";
-  console.log(`${"TOTAL".padEnd(12)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(totRate + "%", 8)}`);
-  if (failures) console.log(`\n${failures} pin(s) failed to fetch (new pins may have no analytics yet).`);
-  console.log(`\nout% = outbound clicks ÷ impressions (the click-through-to-site rate — the lever to optimize).`);
+  L.push(`${"TOTAL".padEnd(12)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(totRate + "%", 8)}`);
+  if (failures) L.push(`\n${failures} pin(s) had no analytics yet (new pins).`);
+  L.push("");
+  L.push(`out% = outbound clicks ÷ impressions — the click-through-to-site rate (the lever to optimize).`);
+  L.push(`Note: these are the drip's own pins only; account-wide reach includes older/manual pins.`);
+
+  const report = L.join("\n");
+  console.log(report);
+
+  if (EMAIL) {
+    const status = await emailReport(report, `${start} → ${end}`);
+    console.log("\n" + status);
+  }
 }
 
 main().catch((e) => {

--- a/scripts/pinterest/analytics-by-type.ts
+++ b/scripts/pinterest/analytics-by-type.ts
@@ -1,0 +1,153 @@
+/**
+ * Pinterest analytics, broken down by PIN TYPE.
+ *
+ * Joins published.json (pinId + key) → the QUEUE's key→type map → per-pin
+ * Pinterest analytics, and aggregates impressions / pin-clicks / outbound-clicks
+ * / saves by type (swatch, guide, palette/room-scene, comparison). This is the
+ * Pinterest-REACH view the cloud Monday digest can't produce (no API access in
+ * the cloud agent) — the digest covers the GA4 site-traffic view via UTM campaign.
+ *
+ * The decision it informs: which pin TYPE converts reach into engagement +
+ * outbound clicks, so the drip's daily mix can shift toward the winner.
+ *
+ * Usage:
+ *   npx tsx scripts/pinterest/analytics-by-type.ts            # last 30 days
+ *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7
+ *   npx tsx scripts/pinterest/analytics-by-type.ts --start=2026-05-27 --end=2026-06-02
+ */
+import "../blog/load-env.ts"; // loads .env.local before anything reads process.env
+import * as path from "path";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import { QUEUE } from "./queue.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = path.resolve(__dirname, "../../.env.local");
+const PUBLISHED_PATH = path.resolve(__dirname, "published.json");
+const API = "https://api.pinterest.com/v5";
+const APP_ID = process.env.PINTEREST_APP_ID!;
+const APP_SECRET = process.env.PINTEREST_APP_SECRET_KEY!;
+let accessToken = process.env.PINTEREST_ACCESS_TOKEN!;
+
+const METRICS = ["IMPRESSION", "PIN_CLICK", "OUTBOUND_CLICK", "SAVE"] as const;
+type Metric = (typeof METRICS)[number];
+
+function arg(name: string): string | undefined {
+  return process.argv.slice(2).find((a) => a.startsWith(`--${name}=`))?.replace(`--${name}=`, "");
+}
+
+/** YYYY-MM-DD, n days before today (UTC). */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function upsertEnv(updates: Record<string, string>) {
+  const lines = fs.readFileSync(ENV_PATH, "utf8").split("\n");
+  for (const [key, value] of Object.entries(updates)) {
+    const idx = lines.findIndex((l) => l.startsWith(`${key}=`));
+    const line = `${key}=${value}`;
+    if (idx >= 0) lines[idx] = line;
+    else lines.push(line);
+  }
+  fs.writeFileSync(ENV_PATH, lines.join("\n"));
+}
+
+async function refreshAccessToken(): Promise<void> {
+  const refresh = process.env.PINTEREST_REFRESH_TOKEN;
+  if (!refresh) throw new Error("401 and no PINTEREST_REFRESH_TOKEN — re-run pinterest-auth.ts");
+  const basic = Buffer.from(`${APP_ID}:${APP_SECRET}`).toString("base64");
+  const res = await fetch(`${API}/oauth/token`, {
+    method: "POST",
+    headers: { Authorization: `Basic ${basic}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: refresh }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Token refresh failed (${res.status}): ${JSON.stringify(data)}`);
+  accessToken = data.access_token;
+  const updates: Record<string, string> = { PINTEREST_ACCESS_TOKEN: data.access_token };
+  if (data.refresh_token) updates.PINTEREST_REFRESH_TOKEN = data.refresh_token;
+  upsertEnv(updates);
+  console.log("   ↻ refreshed access token");
+}
+
+async function pinterest(pathname: string, retry = true): Promise<any> {
+  const res = await fetch(`${API}${pathname}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const data = await res.json().catch(() => ({}));
+  const isScopeError = typeof data?.message === "string" && /scope|Missing:/i.test(data.message);
+  if (res.status === 401 && retry && !isScopeError) {
+    await refreshAccessToken();
+    return pinterest(pathname, false);
+  }
+  if (!res.ok) throw new Error(`${res.status} ${pathname}: ${JSON.stringify(data).slice(0, 200)}`);
+  return data;
+}
+
+/** Sum a single pin's summary metrics over the window. Returns zeros on failure. */
+async function pinSummary(pinId: string, start: string, end: string): Promise<Record<Metric, number>> {
+  const q = `start_date=${start}&end_date=${end}&metric_types=${METRICS.join(",")}`;
+  const data = await pinterest(`/pins/${pinId}/analytics?${q}`);
+  // Pinterest shape: { all: { summary_metrics: {IMPRESSION: n, ...}, daily_metrics: [...] } }
+  const all = data.all ?? data;
+  const summary = all.summary_metrics ?? {};
+  const out = {} as Record<Metric, number>;
+  for (const m of METRICS) out[m] = Number(summary[m] ?? 0);
+  return out;
+}
+
+async function main() {
+  const start = arg("start") ?? daysAgo(arg("days") ? Number(arg("days")) : 30);
+  const end = arg("end") ?? daysAgo(1); // yesterday — today isn't finalized
+
+  const keyToType = new Map<string, string>(QUEUE.map((p) => [p.key, p.type]));
+
+  const published: Record<string, { pinId?: string; publishedAt?: string }> = JSON.parse(
+    fs.readFileSync(PUBLISHED_PATH, "utf8"),
+  );
+  const pins = Object.entries(published)
+    .filter(([, v]) => v.pinId)
+    .map(([key, v]) => ({ key, pinId: v.pinId!, type: keyToType.get(key) ?? key.split(/[-_]/)[0] }));
+
+  console.log(`Pinterest analytics by type — ${start} → ${end} (${pins.length} published pins)\n`);
+
+  type Agg = { pins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number };
+  const byType = new Map<string, Agg>();
+  let failures = 0;
+
+  for (const pin of pins) {
+    let s: Record<Metric, number>;
+    try {
+      s = await pinSummary(pin.pinId, start, end);
+    } catch (e) {
+      failures++;
+      console.error(`  ⚠️  ${pin.key} (${pin.pinId}): ${e instanceof Error ? e.message : e}`);
+      continue;
+    }
+    const a = byType.get(pin.type) ?? { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
+    a.pins += 1;
+    for (const m of METRICS) a[m] += s[m];
+    byType.set(pin.type, a);
+  }
+
+  const rows = [...byType.entries()].sort((x, y) => y[1].IMPRESSION - x[1].IMPRESSION);
+  const pad = (v: string | number, n: number) => String(v).padStart(n);
+  console.log(`${"type".padEnd(12)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
+  console.log("-".repeat(56));
+  const tot: Agg = { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
+  for (const [type, a] of rows) {
+    const outRate = a.IMPRESSION ? ((a.OUTBOUND_CLICK / a.IMPRESSION) * 100).toFixed(2) : "0.00";
+    console.log(`${type.padEnd(12)}${pad(a.pins, 5)}${pad(a.IMPRESSION, 8)}${pad(a.PIN_CLICK, 8)}${pad(a.OUTBOUND_CLICK, 8)}${pad(a.SAVE, 7)}${pad(outRate + "%", 8)}`);
+    tot.pins += a.pins; for (const m of METRICS) tot[m] += a[m];
+  }
+  console.log("-".repeat(56));
+  const totRate = tot.IMPRESSION ? ((tot.OUTBOUND_CLICK / tot.IMPRESSION) * 100).toFixed(2) : "0.00";
+  console.log(`${"TOTAL".padEnd(12)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(totRate + "%", 8)}`);
+  if (failures) console.log(`\n${failures} pin(s) failed to fetch (new pins may have no analytics yet).`);
+  console.log(`\nout% = outbound clicks ÷ impressions (the click-through-to-site rate — the lever to optimize).`);
+}
+
+main().catch((e) => {
+  console.error("Error:", e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/scripts/pinterest/analytics-by-type.ts
+++ b/scripts/pinterest/analytics-by-type.ts
@@ -1,31 +1,34 @@
 /**
- * Pinterest analytics, broken down by PIN TYPE.
+ * Pinterest reach by PIN TYPE — across ALL owned pins on the account.
  *
- * Joins published.json (pinId + key) → the QUEUE's key→type map → per-pin
- * Pinterest analytics, and aggregates impressions / pin-clicks / outbound-clicks
- * / saves by type (swatch, guide, palette/room-scene, comparison). This is the
- * Pinterest-REACH view the cloud Monday digest can't produce (no API access in
- * the cloud agent) — the digest covers the GA4 site-traffic view via UTM campaign.
+ * Enumerates every owned pin (GET /v5/pins, paginated — old + manual + drip),
+ * buckets each by its BOARD (boards map 1:1 to our types: swatch / palette /
+ * guide / comparison; anything else → "other"), pulls per-pin analytics, and
+ * aggregates impressions / pin-clicks / outbound-clicks / saves by type. Also
+ * flags how many pins in each type came from the automated drip (published.json)
+ * and the drip's share of impressions — so you see total account reach AND the
+ * drip-tuning signal in one table.
  *
- * The decision it informs: which pin TYPE converts reach into engagement +
- * outbound clicks, so the drip's daily mix can shift toward the winner.
+ * (Third-party REPINS can't be included — Pinterest only exposes analytics for
+ * pins the account owns.)
+ *
+ * This is the Pinterest-reach view the cloud Monday GA4 digest can't produce.
  *
  * Usage:
  *   npx tsx scripts/pinterest/analytics-by-type.ts            # last 30 days → stdout
  *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7
  *   npx tsx scripts/pinterest/analytics-by-type.ts --start=2026-05-27 --end=2026-06-02
- *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7 --email   # also email via Resend
+ *   npx tsx scripts/pinterest/analytics-by-type.ts --days=7 --email   # styled HTML via Resend
  *
- * --email sends a styled HTML report through Resend IF RESEND_API_KEY is set in
- * .env.local (to REPORT_EMAIL_TO, default philip@theorphanshands.org). If the key
- * is absent it prints a notice and skips — the plain-text report still prints for
- * the launchd wrapper, which writes it to a file + macOS notification regardless.
+ * --email sends through Resend IF RESEND_API_KEY is set in .env.local (to
+ * REPORT_EMAIL_TO, default philip@theorphanshands.org); otherwise it's a no-op
+ * and the launchd wrapper still writes the report file + a macOS notification.
  */
 import "../blog/load-env.ts"; // loads .env.local before anything reads process.env
 import * as path from "path";
 import * as fs from "fs";
 import { fileURLToPath } from "url";
-import { QUEUE } from "./queue.ts";
+import { BOARD_IDS, TYPE_FOR_BOARD } from "./queue.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ENV_PATH = path.resolve(__dirname, "../../.env.local");
@@ -38,13 +41,18 @@ let accessToken = process.env.PINTEREST_ACCESS_TOKEN!;
 const METRICS = ["IMPRESSION", "PIN_CLICK", "OUTBOUND_CLICK", "SAVE"] as const;
 type Metric = (typeof METRICS)[number];
 
-/** Friendly labels for the pin types stored in the queue. */
 const TYPE_LABEL: Record<string, string> = {
   swatch: "Swatch",
   guide: "Guide / blog",
   palette: "Room scene",
   comparison: "Comparison",
+  other: "Other / older",
 };
+
+// boardId → our pin type (invert BOARD_IDS, then TYPE_FOR_BOARD by board name).
+const BOARD_ID_TO_TYPE: Record<string, string> = Object.fromEntries(
+  Object.entries(BOARD_IDS).map(([name, id]) => [id, TYPE_FOR_BOARD[name as keyof typeof TYPE_FOR_BOARD]]),
+);
 
 const args = process.argv.slice(2);
 const EMAIL = args.includes("--email");
@@ -86,8 +94,16 @@ async function refreshAccessToken(): Promise<void> {
   upsertEnv(updates);
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 async function pinterest(pathname: string, retry = true): Promise<any> {
   const res = await fetch(`${API}${pathname}`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  // Rate limited — wait (honor Retry-After) and retry a few times.
+  if (res.status === 429 && retry) {
+    const wait = Number(res.headers.get("retry-after")) * 1000 || 3000;
+    await sleep(wait);
+    return pinterest(pathname, true);
+  }
   const data = await res.json().catch(() => ({}));
   const isScopeError = typeof data?.message === "string" && /scope|Missing:/i.test(data.message);
   if (res.status === 401 && retry && !isScopeError) {
@@ -96,6 +112,19 @@ async function pinterest(pathname: string, retry = true): Promise<any> {
   }
   if (!res.ok) throw new Error(`${res.status} ${pathname}: ${JSON.stringify(data).slice(0, 200)}`);
   return data;
+}
+
+/** Every owned pin: id + board_id, following pagination bookmarks. */
+async function fetchOwnedPins(): Promise<{ id: string; boardId: string }[]> {
+  const out: { id: string; boardId: string }[] = [];
+  let bookmark = "";
+  do {
+    const qs = `page_size=100&pin_fields=id,board_id${bookmark ? `&bookmark=${encodeURIComponent(bookmark)}` : ""}`;
+    const data = await pinterest(`/pins?${qs}`);
+    for (const it of data.items ?? []) out.push({ id: it.id, boardId: it.board_id ?? "" });
+    bookmark = data.bookmark ?? "";
+  } while (bookmark);
+  return out;
 }
 
 async function pinSummary(pinId: string, start: string, end: string): Promise<Record<Metric, number>> {
@@ -108,66 +137,74 @@ async function pinSummary(pinId: string, start: string, end: string): Promise<Re
   return out;
 }
 
-interface Agg { pins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number }
+interface Agg { pins: number; dripPins: number; IMPRESSION: number; PIN_CLICK: number; OUTBOUND_CLICK: number; SAVE: number; dripImpr: number }
 interface Row extends Agg { type: string }
 
 const num = (n: number) => n.toLocaleString("en-US");
 const rate = (a: Agg) => (a.IMPRESSION ? ((a.OUTBOUND_CLICK / a.IMPRESSION) * 100).toFixed(2) : "0.00") + "%";
 
-/** Plain-text table — for the terminal and the saved report file. */
-function buildText(rows: Row[], tot: Agg, start: string, end: string, pinCount: number): string {
+/** Plain-text table — terminal + saved report file. */
+function buildText(rows: Row[], tot: Agg, start: string, end: string): string {
   const L: string[] = [];
   const pad = (v: string | number, n: number) => String(v).padStart(n);
-  L.push(`Pinterest reach by pin type — ${start} → ${end} (${pinCount} drip pins)`);
+  L.push(`Pinterest reach by pin type — ${start} → ${end}`);
+  L.push(`${tot.pins} owned pins (${tot.dripPins} from the drip)`);
   L.push("");
-  L.push(`${"type".padEnd(13)}${pad("pins", 5)}${pad("impr", 8)}${pad("pinClk", 8)}${pad("outClk", 8)}${pad("saves", 7)}${pad("out%", 8)}`);
-  L.push("-".repeat(57));
+  L.push(`${"type".padEnd(15)}${pad("pins", 5)}${pad("drip", 5)}${pad("impr", 8)}${pad("pinClk", 7)}${pad("outClk", 7)}${pad("saves", 6)}${pad("out%", 7)}`);
+  L.push("-".repeat(60));
   for (const r of rows) {
-    L.push(`${(TYPE_LABEL[r.type] ?? r.type).padEnd(13)}${pad(r.pins, 5)}${pad(r.IMPRESSION, 8)}${pad(r.PIN_CLICK, 8)}${pad(r.OUTBOUND_CLICK, 8)}${pad(r.SAVE, 7)}${pad(rate(r), 8)}`);
+    L.push(`${(TYPE_LABEL[r.type] ?? r.type).padEnd(15)}${pad(r.pins, 5)}${pad(r.dripPins, 5)}${pad(num(r.IMPRESSION), 8)}${pad(num(r.PIN_CLICK), 7)}${pad(num(r.OUTBOUND_CLICK), 7)}${pad(num(r.SAVE), 6)}${pad(rate(r), 7)}`);
   }
-  L.push("-".repeat(57));
-  L.push(`${"TOTAL".padEnd(13)}${pad(tot.pins, 5)}${pad(tot.IMPRESSION, 8)}${pad(tot.PIN_CLICK, 8)}${pad(tot.OUTBOUND_CLICK, 8)}${pad(tot.SAVE, 7)}${pad(rate(tot), 8)}`);
+  L.push("-".repeat(60));
+  L.push(`${"TOTAL".padEnd(15)}${pad(tot.pins, 5)}${pad(tot.dripPins, 5)}${pad(num(tot.IMPRESSION), 8)}${pad(num(tot.PIN_CLICK), 7)}${pad(num(tot.OUTBOUND_CLICK), 7)}${pad(num(tot.SAVE), 6)}${pad(rate(tot), 7)}`);
+  const share = tot.IMPRESSION ? ((tot.dripImpr / tot.IMPRESSION) * 100).toFixed(1) : "0.0";
   L.push("");
+  L.push(`Drip pins account for ${share}% of impressions (${num(tot.dripImpr)} of ${num(tot.IMPRESSION)}); the rest is older/manual pins.`);
   L.push(`out% = outbound clicks ÷ impressions — the click-through-to-site rate (the lever to optimize).`);
-  L.push(`Note: the drip's own pins only; account-wide reach also includes older/manual pins.`);
+  L.push(`Excludes third-party repins (analytics only available for owned pins).`);
   return L.join("\n");
 }
 
 /** Styled HTML table — inline CSS only (email clients strip <style>). */
-function buildHtml(rows: Row[], tot: Agg, start: string, end: string, pinCount: number): string {
+function buildHtml(rows: Row[], tot: Agg, start: string, end: string): string {
   const wrap = "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1a1a1a;";
-  const th = "padding:8px 12px;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#ffffff;background:#2b2b2b;text-align:right;";
+  const th = "padding:8px 10px;font-size:11px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:#ffffff;background:#2b2b2b;text-align:right;";
   const thL = th.replace("text-align:right;", "text-align:left;");
-  const td = "padding:8px 12px;font-size:14px;text-align:right;border-bottom:1px solid #ececec;font-variant-numeric:tabular-nums;";
-  const tdL = td.replace("text-align:right;", "text-align:left;font-weight:600;");
-  const cell = (r: Row | Agg, key: Metric) => `<td style="${td}">${num(r[key])}</td>`;
+  const td = "padding:8px 10px;font-size:14px;text-align:right;border-bottom:1px solid #ececec;font-variant-numeric:tabular-nums;";
+  const tdL = "padding:8px 10px;font-size:14px;text-align:left;font-weight:600;border-bottom:1px solid #ececec;";
+  const tot_ = "border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;";
 
-  const bodyRows = rows
-    .map((r, i) => {
-      const bg = i % 2 ? "background:#fafafa;" : "";
-      const label = TYPE_LABEL[r.type] ?? r.type;
-      return `<tr style="${bg}">
-        <td style="${tdL}${bg}">${label}</td>
-        <td style="${td}${bg}">${num(r.pins)}</td>
-        ${cell(r, "IMPRESSION")}${cell(r, "PIN_CLICK")}${cell(r, "OUTBOUND_CLICK")}${cell(r, "SAVE")}
-        <td style="${td}${bg}font-weight:600;color:#0a66c2;">${rate(r)}</td>
-      </tr>`;
-    })
-    .join("");
+  const row = (r: Row, i: number) => {
+    const bg = i % 2 ? "background:#fafafa;" : "";
+    const pinsCell = r.dripPins
+      ? `${num(r.pins)} <span style="color:#999;font-size:12px;">(${r.dripPins} drip)</span>`
+      : num(r.pins);
+    return `<tr>
+      <td style="${tdL}${bg}">${TYPE_LABEL[r.type] ?? r.type}</td>
+      <td style="${td}${bg}">${pinsCell}</td>
+      <td style="${td}${bg}">${num(r.IMPRESSION)}</td>
+      <td style="${td}${bg}">${num(r.PIN_CLICK)}</td>
+      <td style="${td}${bg}">${num(r.OUTBOUND_CLICK)}</td>
+      <td style="${td}${bg}">${num(r.SAVE)}</td>
+      <td style="${td}${bg}font-weight:600;color:#0a66c2;">${rate(r)}</td>
+    </tr>`;
+  };
 
   const totRow = `<tr>
-    <td style="${tdL}border-top:2px solid #2b2b2b;border-bottom:none;">Total</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.pins)}</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.IMPRESSION)}</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.PIN_CLICK)}</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.OUTBOUND_CLICK)}</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;">${num(tot.SAVE)}</td>
-    <td style="${td}border-top:2px solid #2b2b2b;border-bottom:none;font-weight:700;color:#0a66c2;">${rate(tot)}</td>
+    <td style="${tdL}${tot_}">Total</td>
+    <td style="${td}${tot_}">${num(tot.pins)}${tot.dripPins ? ` <span style="color:#bbb;font-size:12px;">(${tot.dripPins} drip)</span>` : ""}</td>
+    <td style="${td}${tot_}">${num(tot.IMPRESSION)}</td>
+    <td style="${td}${tot_}">${num(tot.PIN_CLICK)}</td>
+    <td style="${td}${tot_}">${num(tot.OUTBOUND_CLICK)}</td>
+    <td style="${td}${tot_}">${num(tot.SAVE)}</td>
+    <td style="${td}${tot_}color:#0a66c2;">${rate(tot)}</td>
   </tr>`;
 
-  return `<div style="${wrap}max-width:640px;margin:0 auto;padding:8px 4px;">
+  const share = tot.IMPRESSION ? ((tot.dripImpr / tot.IMPRESSION) * 100).toFixed(1) : "0.0";
+
+  return `<div style="${wrap}max-width:680px;margin:0 auto;padding:8px 4px;">
     <h2 style="font-size:18px;margin:0 0 2px;">Pinterest reach by pin type</h2>
-    <p style="margin:0 0 16px;color:#666;font-size:13px;">${start} → ${end} · ${pinCount} drip pins</p>
+    <p style="margin:0 0 16px;color:#666;font-size:13px;">${start} → ${end} · ${num(tot.pins)} owned pins (${tot.dripPins} from the drip)</p>
     <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse;width:100%;border:1px solid #ececec;border-radius:8px;overflow:hidden;">
       <thead><tr>
         <th style="${thL}">Pin type</th>
@@ -178,13 +215,14 @@ function buildHtml(rows: Row[], tot: Agg, start: string, end: string, pinCount: 
         <th style="${th}">Saves</th>
         <th style="${th}">Out&nbsp;rate</th>
       </tr></thead>
-      <tbody>${bodyRows}${totRow}</tbody>
+      <tbody>${rows.map(row).join("")}${totRow}</tbody>
     </table>
-    <p style="margin:16px 0 4px;color:#666;font-size:12px;line-height:1.5;">
-      <strong>Out rate</strong> = outbound clicks ÷ impressions — the click-through-to-site rate, the lever to optimize.
+    <p style="margin:16px 0 4px;color:#444;font-size:12px;line-height:1.5;">
+      Drip pins account for <strong>${share}%</strong> of impressions; the rest is older / manual pins.
     </p>
     <p style="margin:0;color:#999;font-size:12px;line-height:1.5;">
-      The drip's own pins only; account-wide reach also includes older/manual pins. PaintColorHQ weekly.
+      <strong>Out rate</strong> = outbound clicks ÷ impressions (click-through-to-site, the lever to optimize).
+      Excludes third-party repins — analytics are only available for owned pins. PaintColorHQ weekly.
     </p>
   </div>`;
 }
@@ -212,41 +250,54 @@ async function main() {
   const start = arg("start") ?? daysAgo(arg("days") ? Number(arg("days")) : 30);
   const end = arg("end") ?? daysAgo(1); // yesterday — today isn't finalized
 
-  const keyToType = new Map<string, string>(QUEUE.map((p) => [p.key, p.type] as [string, string]));
-  const published: Record<string, { pinId?: string; publishedAt?: string }> = JSON.parse(
-    fs.readFileSync(PUBLISHED_PATH, "utf8"),
+  const dripIds = new Set<string>(
+    Object.values(JSON.parse(fs.readFileSync(PUBLISHED_PATH, "utf8")) as Record<string, { pinId?: string }>)
+      .map((v) => v.pinId)
+      .filter(Boolean) as string[],
   );
-  const pins = Object.entries(published)
-    .filter(([, v]) => v.pinId)
-    .map(([key, v]) => ({ key, pinId: v.pinId!, type: keyToType.get(key) ?? key.split(/[-_]/)[0] }));
+
+  const owned = await fetchOwnedPins();
+  console.error(`Fetching analytics for ${owned.length} owned pins…`);
 
   const byType = new Map<string, Agg>();
   let failures = 0;
-  for (const pin of pins) {
+  let firstError = "";
+  for (const pin of owned) {
     let s: Record<Metric, number>;
     try {
-      s = await pinSummary(pin.pinId, start, end);
-    } catch {
+      s = await pinSummary(pin.id, start, end);
+      await sleep(120); // gentle throttle — stay under Pinterest's per-pin rate limit
+    } catch (e) {
       failures++;
+      if (!firstError) firstError = e instanceof Error ? e.message : String(e);
       continue;
     }
-    const a = byType.get(pin.type) ?? { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
+    const type = BOARD_ID_TO_TYPE[pin.boardId] ?? "other";
+    const a = byType.get(type) ?? { pins: 0, dripPins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0, dripImpr: 0 };
     a.pins += 1;
     for (const m of METRICS) a[m] += s[m];
-    byType.set(pin.type, a);
+    if (dripIds.has(pin.id)) {
+      a.dripPins += 1;
+      a.dripImpr += s.IMPRESSION;
+    }
+    byType.set(type, a);
   }
 
   const rows: Row[] = [...byType.entries()]
     .map(([type, a]) => ({ type, ...a }))
     .sort((x, y) => y.IMPRESSION - x.IMPRESSION);
-  const tot: Agg = { pins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0 };
-  for (const r of rows) { tot.pins += r.pins; for (const m of METRICS) tot[m] += r[m]; }
+  const tot: Agg = { pins: 0, dripPins: 0, IMPRESSION: 0, PIN_CLICK: 0, OUTBOUND_CLICK: 0, SAVE: 0, dripImpr: 0 };
+  for (const r of rows) {
+    tot.pins += r.pins; tot.dripPins += r.dripPins; tot.dripImpr += r.dripImpr;
+    for (const m of METRICS) tot[m] += r[m];
+  }
 
-  const text = buildText(rows, tot, start, end, pins.length) + (failures ? `\n(${failures} pin(s) had no analytics yet.)` : "");
+  if (failures) console.error(`${failures} pin(s) failed${firstError ? ` — first: ${firstError}` : ""}`);
+  const text = buildText(rows, tot, start, end) + (failures ? `\n(${failures} pin(s) had no analytics for this window.)` : "");
   console.log(text);
 
   if (EMAIL) {
-    const html = buildHtml(rows, tot, start, end, pins.length);
+    const html = buildHtml(rows, tot, start, end);
     console.log("\n" + (await emailReport(text, html, `${start} → ${end}`)));
   }
 }

--- a/scripts/pinterest/analytics-report.sh
+++ b/scripts/pinterest/analytics-report.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# launchd entry point for the weekly Pinterest reach-by-type report.
+# Runs the analytics for the last 7 days, writes a dated report file + a
+# `latest` copy, fires a macOS notification, and (via --email) emails it
+# through Resend IF RESEND_API_KEY is set in .env.local. Logs to analytics.log.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+DIR="$REPO/scripts/pinterest"
+mkdir -p "$DIR/reports"
+STAMP="$(date +%Y-%m-%d)"
+LOG="$DIR/analytics.log"
+
+echo "=== analytics run $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "$LOG"
+# Capture the report; --email sends via Resend when a key exists (else no-op).
+REPORT="$(npx tsx scripts/pinterest/analytics-by-type.ts --days=7 --email 2>>"$LOG" | grep -v 'injecting env' || true)"
+echo "$REPORT" | tee "$DIR/reports/$STAMP.txt" > "$DIR/reports/latest.txt"
+echo "$REPORT" >> "$LOG"
+
+# macOS banner so it surfaces even if email isn't wired up.
+SUMMARY="$(echo "$REPORT" | grep '^TOTAL' || echo 'report ready')"
+osascript -e "display notification \"${SUMMARY//\"/\'}\" with title \"PaintColorHQ — Pinterest weekly\"" 2>/dev/null || true

--- a/scripts/pinterest/com.paintcolorhq.pinterest-analytics.plist.template
+++ b/scripts/pinterest/com.paintcolorhq.pinterest-analytics.plist.template
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>__LABEL__</string>
+  <!-- Invoke /bin/bash DIRECTLY (not the script via its shebang): macOS TCC
+       attributes file access to the launchd program, so the FDA-granted
+       /bin/bash must be the program. Same Full Disk Access grant as the drip
+       agent (/bin/bash + node) covers this — no new grant needed. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__REPORTSH__</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>__NODE_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <!-- StartCalendarInterval is LOCAL time. Weekday 1 = Monday, 09:00 local —
+       a Monday-morning reach report alongside the cloud GA4 digest. -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key><integer>1</integer>
+    <key>Hour</key><integer>9</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardErrorPath</key><string>__REPO__/scripts/pinterest/analytics.log</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/pinterest/install-analytics-schedule.sh
+++ b/scripts/pinterest/install-analytics-schedule.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Render + (un)load the weekly Pinterest analytics-by-type launchd agent.
+# Run from the PERMANENT repo checkout (the agent references this path).
+#
+# Usage: ./install-analytics-schedule.sh           # install
+#        ./install-analytics-schedule.sh uninstall # remove
+set -euo pipefail
+LABEL="com.paintcolorhq.pinterest-analytics"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if [[ "${1:-}" == "uninstall" ]]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "Uninstalled $LABEL."
+  exit 0
+fi
+
+REPORTSH="$REPO/scripts/pinterest/analytics-report.sh"
+NODE_DIR="$(dirname "$(command -v node)")"
+chmod +x "$REPORTSH"
+mkdir -p "$HOME/Library/LaunchAgents"
+sed -e "s|__LABEL__|$LABEL|g" \
+    -e "s|__REPORTSH__|$REPORTSH|g" \
+    -e "s|__NODE_DIR__|$NODE_DIR|g" \
+    -e "s|__REPO__|$REPO|g" \
+    "$REPO/scripts/pinterest/com.paintcolorhq.pinterest-analytics.plist.template" > "$PLIST"
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+echo "Installed $LABEL — runs the reach-by-type report every Monday 09:00 LOCAL."
+echo "Reports: $REPO/scripts/pinterest/reports/<date>.txt (+ latest.txt); log: analytics.log"
+echo "Uses the SAME Full Disk Access grant as the drip (/bin/bash + node) — no new grant needed."
+echo "Email: set RESEND_API_KEY (and optional REPORT_EMAIL_TO) in .env.local to enable the email leg;"
+echo "       until then it writes the report file + a macOS notification."
+echo "Uninstall: ./scripts/pinterest/install-analytics-schedule.sh uninstall"


### PR DESCRIPTION
## Summary
Local script that produces the **Pinterest-reach view by pin type** — the complement to the Monday cloud digest's GA4/UTM site-traffic view (which can't reach the Pinterest API).

`scripts/pinterest/analytics-by-type.ts` joins `published.json` (pinId + key) → the QUEUE's `key→type` map → per-pin Pinterest v5 analytics, and aggregates **impressions / pin-clicks / outbound-clicks / saves by type** (swatch, guide, palette, comparison) plus the **outbound-click rate** (the click-through-to-site lever). Reuses the publisher's token-refresh-on-401 pattern. Read-only (no posting).

```
npx tsx scripts/pinterest/analytics-by-type.ts            # last 30 days
npx tsx scripts/pinterest/analytics-by-type.ts --days=7
npx tsx scripts/pinterest/analytics-by-type.ts --start=2026-05-27 --end=2026-06-02
```

## First run (5/27–6/2)
The 33 automated pins drew only ~87 impressions in the window — they're days old. Account-level reach (9,537 impressions) comes mostly from older/manual pins. The one outbound click came from a guide pin. Volume is far too low to draw conclusions yet — the script is the instrument; the read comes in a few weeks.

## Note
Dev-only utility (not imported by the build, no deploy impact). Lives alongside the other `scripts/pinterest/` tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)