### PR TITLE
seo: audit quick-wins (noindex /compare, author/founder sameAs, match-link fix, cookie bar, llms.txt)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@
 ## Common Questions This Site Answers
 - What is the Benjamin Moore equivalent of Sherwin-Williams Agreeable Gray? → Wish AF-680 (Delta E 0.91) — virtually identical on walls.
 - What is the Behr equivalent of Agreeable Gray? → Toasty Gray N320-2 (Delta E 1.4) — very close, available at Home Depot.
-- What undertone does Agreeable Gray have? → Warm balanced neutral — no single undertone dominates, which is why it works in most lighting conditions.
+- What undertone does Agreeable Gray have? → It's classified as a neutral and reads as a warm greige — no single undertone dominates, which is why it works in most lighting conditions.
 - What is the best white paint for trim? → Chantilly Lace (true white, LRV 90) or White Dove (warm white, LRV 83) for a creamier look.
 - What is the best white paint for cabinets? → Simply White (2143-70, LRV 89) for warm kitchens; Chantilly Lace (2121-70, LRV 90) for modern/bright kitchens.
 - What is the difference between Repose Gray and Agreeable Gray? → Repose Gray (LRV 58) is a true neutral with no dominant undertone; Agreeable Gray (LRV 60) is a warm greige. Both are top sellers; Agreeable Gray reads warmer.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -229,7 +229,7 @@ export default async function BlogPostPage({ params }: PageProps) {
           width: 1200,
           height: 630,
         },
-        author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Founder, Paint Color HQ", worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
+        author: { "@type": "Person", name: post.author, url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff", jobTitle: "Founder, Paint Color HQ", sameAs: ["https://www.linkedin.com/in/philip-a-cameron/", "https://github.com/pcameron80"], worksFor: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com" } },
         publisher: { "@type": "Organization", name: "Paint Color HQ", url: "https://www.paintcolorhq.com", logo: { "@type": "ImageObject", url: "https://www.paintcolorhq.com/logo.webp", width: 600, height: 60 } },
       }} />
       <JsonLd data={{

--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -9,7 +9,7 @@ import { BrandColorLibrary } from "@/components/brand-color-library";
 import { BrandColorLibraryFallback } from "@/components/brand-color-library-fallback";
 import { getBrandBySlug, getColorsBySlugList, getColorsByBrand, getColorsByBrandCount, getAllBrands } from "@/lib/queries";
 import { getBrandContent } from "@/lib/brand-content";
-import { POPULAR_COLOR_SLUGS } from "@/lib/popular-colors";
+import { POPULAR_COLOR_SLUGS, MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
 import { AdSenseScript } from "@/components/adsense-script";
 import { TrackPage } from "@/components/track-page";
 import { ColorLinkEnhancer } from "@/components/color-link-enhancer";
@@ -97,14 +97,25 @@ export default async function BrandPage({ params }: PageProps) {
     .filter((p) => p.brandSlug === brandSlug)
     .map((p) => p.colorSlug);
 
-  const [colors, totalCount, popularColors] = await Promise.all([
+  const [colors, totalCount, popularColors, allBrands] = await Promise.all([
     getColorsByBrand(brand.id, { limit: perPage, offset: 0 }),
     getColorsByBrandCount(brand.id),
     // Single batched query replaces N parallel getColorBySlug round-trips
     // (audit perf finding from H2.2 PR #54). Up to 11 fewer DB hits per
     // brand-page render.
     getColorsBySlugList(brandSlug, popularSlugsForBrand),
+    getAllBrands(),
   ]);
+
+  // Cross-brand match targets: drive off MAJOR_MATCH_BRANDS (the canonical list
+  // the /match routes + sitemap use) so every brand-pair listing has an internal
+  // link. A stale hardcoded list previously orphaned dunn-edwards & farrow-ball.
+  // Names resolved from the DB so display strings stay correct (e.g. "Farrow & Ball").
+  const matchTargets = MAJOR_MATCH_BRANDS
+    .filter((slug) => slug !== brandSlug)
+    .map((slug) => allBrands.find((b) => b.slug === slug))
+    .filter((b): b is NonNullable<typeof b> => Boolean(b))
+    .map((b) => ({ slug: b.slug, name: b.name }));
 
   const families: { name: string; hex: string; border?: boolean }[] = [
     { name: "white", hex: "#FFFFFF", border: true },
@@ -299,14 +310,7 @@ export default async function BrandPage({ params }: PageProps) {
 
       {/* Cross-Brand Matching */}
       {(() => {
-        const majorBrands = [
-          { slug: "sherwin-williams", name: "Sherwin-Williams" },
-          { slug: "benjamin-moore", name: "Benjamin Moore" },
-          { slug: "behr", name: "Behr" },
-          { slug: "ppg", name: "PPG" },
-          { slug: "valspar", name: "Valspar" },
-        ];
-        const targets = majorBrands.filter((b) => b.slug !== brandSlug).slice(0, 5);
+        const targets = matchTargets;
         if (targets.length === 0) return null;
         return (
           <section className="py-20 px-6 md:px-12 bg-surface">

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -5,14 +5,21 @@ import { AdSenseScript } from "@/components/adsense-script";
 import { getColorById } from "@/lib/queries";
 import { CompareClient } from "./compare-client";
 
-export const metadata: Metadata = {
-  title: "Compare Paint Colors Side by Side",
-  description: "Compare any two paint colors side by side with hex codes, RGB values, LRV, and visual swatches.",
-  alternates: { canonical: "https://www.paintcolorhq.com/compare" },
-  openGraph: { title: "Compare Paint Colors Side by Side", description: "Compare any two paint colors side by side.", url: "https://www.paintcolorhq.com/compare" },
-};
-
 interface PageProps { searchParams: Promise<{ color1?: string; color2?: string }>; }
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const { color1, color2 } = await searchParams;
+  const hasParams = Boolean(color1 || color2);
+  return {
+    title: "Compare Paint Colors Side by Side",
+    description: "Compare any two paint colors side by side with hex codes, RGB values, LRV, and visual swatches.",
+    alternates: { canonical: "https://www.paintcolorhq.com/compare" },
+    // Parametric compare URLs are combinatorial thin-content — keep them out of the index
+    // (robots.txt Disallow blocks crawl, not indexing). Mirrors /search behaviour.
+    ...(hasParams && { robots: { index: false, follow: true } }),
+    openGraph: { title: "Compare Paint Colors Side by Side", description: "Compare any two paint colors side by side.", url: "https://www.paintcolorhq.com/compare" },
+  };
+}
 
 // JSON-LD helper - all content is server-generated from trusted static values
 function JsonLd({ data }: { data: object }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -401,6 +401,13 @@ export default async function Home() {
         logo: "https://www.paintcolorhq.com/logo.webp",
         description: "Paint Color HQ helps you discover, preview, and compare 23,000+ paint colors across 14 brands, then find your color in the brand you can buy. Cross-brand matches use the CIEDE2000 Delta E formula. Free, no signup.",
         sameAs: ["https://www.pinterest.com/paintcolorhq"],
+        founder: {
+          "@type": "Person",
+          name: "Philip Cameron",
+          url: "https://www.paintcolorhq.com/authors/paint-color-hq-staff",
+          jobTitle: "Founder, Paint Color HQ",
+          sameAs: ["https://www.linkedin.com/in/philip-a-cameron/", "https://github.com/pcameron80"],
+        },
         contactPoint: { "@type": "ContactPoint", contactType: "customer support", url: "https://www.paintcolorhq.com/contact" },
       }} />
 

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -78,26 +78,27 @@ export function CookieConsent() {
       )}
 
       {visible && (
-        <div className="fixed bottom-0 inset-x-0 z-[100] p-4 sm:p-6">
-          <div className="mx-auto max-w-2xl rounded-2xl border border-outline-variant/20 bg-surface-container-lowest p-5 shadow-xl sm:flex sm:items-center sm:gap-6">
-            <p className="text-sm text-on-surface-variant leading-relaxed sm:flex-1">
-              We use cookies for analytics and to improve your experience. See
-              our{" "}
+        <div className="fixed bottom-0 inset-x-0 z-[100] p-2 sm:p-6">
+          {/* Compact single-row bar on mobile so it doesn't cover CTAs / editorial
+              above the fold (audit visual finding). Roomier card on >= sm. */}
+          <div className="mx-auto flex max-w-2xl items-center gap-3 rounded-xl border border-outline-variant/20 bg-surface-container-lowest px-3 py-2.5 shadow-xl sm:gap-6 sm:rounded-2xl sm:p-5">
+            <p className="flex-1 text-xs leading-snug text-on-surface-variant sm:text-sm sm:leading-relaxed">
+              We use cookies for analytics.{" "}
               <a href="/privacy" className="text-primary underline">
                 Privacy Policy
               </a>
               .
             </p>
-            <div className="mt-4 flex gap-3 sm:mt-0 sm:shrink-0">
+            <div className="flex shrink-0 gap-2 sm:gap-3">
               <button
                 onClick={handleDecline}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-on-surface-variant transition-colors hover:bg-surface-container"
+                className="rounded-lg px-3 py-1.5 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container sm:px-4 sm:py-2 sm:text-sm"
               >
                 Decline
               </button>
               <button
                 onClick={handleAccept}
-                className="rounded-lg bg-primary px-5 py-2 text-sm font-bold text-on-primary transition-colors hover:bg-primary/90"
+                className="rounded-lg bg-primary px-4 py-1.5 text-xs font-bold text-on-primary transition-colors hover:bg-primary/90 sm:px-5 sm:py-2 sm:text-sm"
               >
                 Accept
               </button>


### PR DESCRIPTION
## Summary
The five low-risk quick wins from the **2026-06-03 full SEO audit** (claude-seo v2.0.0, 11 specialists). All small, independent, additive.

| # | Fix | File |
|---|-----|------|
| C2 | `noindex,follow` on `/compare?` when params present (stops combinatorial thin-content indexing during HCU recovery; mirrors `/search`) | `src/app/compare/page.tsx` |
| H2 | author `sameAs` (LinkedIn + GitHub) on BlogPosting; `founder` Person on homepage Organization — the named-author E-E-A-T signal existed only on the `/authors` page | `src/app/blog/[slug]/page.tsx`, `src/app/page.tsx` |
| H3 | brand-page Cross-Brand Matching links now driven by `MAJOR_MATCH_BRANDS` (names from DB) — fixes orphaned `SW→dunn-edwards` / `SW→farrow-ball` listings for all 7 brands | `src/app/brands/[brandSlug]/page.tsx` |
| M1 | compact single-row cookie banner on mobile (no longer covers CTAs / above-the-fold editorial sitewide) | `src/components/cookie-consent.tsx` |
| M8 | reconcile llms.txt Agreeable Gray undertone with schema classification (removes AI-citation contradiction) | `public/llms.txt` |

## Verification
- [x] `tsc` clean on all 5 changed files (the only tsc errors are the pre-existing `scripts/*` `.tsx`-import pattern, which `.vercelignore` strips from the Vercel build — main builds green with them).
- [x] All `src/` compiled locally; the brand-page `matchTargets` change type-checks.
- [x] `seo-preflight`: GO (no external links w/o rel, no title/meta length regressions, additive schema, intentional noindex on param pages only).
- [ ] Vercel preview build (authoritative gate)

Full audit + action plan live on disk at `seo-audits/2026-06-03-full-audit/` (not in this PR to keep it code-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)