### PR TITLE
seo(content-system): diversify color descriptions + make editorial extractable (HCU recovery)

### DIFF
--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -185,9 +185,9 @@ export default async function BrandPage({ params }: PageProps) {
               <h2 className="font-headline text-3xl font-bold tracking-tight text-on-surface">About {brand.name}</h2>
               <div className="bg-primary h-1 w-12 mt-4" />
             </div>
-            <div id="brand-intro" className="max-w-4xl text-on-surface-variant leading-relaxed">
+            <article id="brand-intro" className="max-w-4xl text-on-surface-variant leading-relaxed">
               {brandContent.intro}
-            </div>
+            </article>
             <ColorLinkEnhancer containerRef="brand-intro" />
           </div>
         </section>
@@ -300,9 +300,9 @@ export default async function BrandPage({ params }: PageProps) {
       {brandContent?.details && (
         <section className="py-16 px-6 md:px-12 bg-tertiary-fixed">
           <div className="max-w-7xl mx-auto">
-            <div id="brand-details" className="max-w-4xl text-on-surface-variant">
+            <article id="brand-details" className="max-w-4xl text-on-surface-variant">
               {brandContent.details}
-            </div>
+            </article>
             <ColorLinkEnhancer containerRef="brand-details" />
           </div>
         </section>

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -169,9 +169,9 @@ export default async function ColorFamilyPage({ params }: PageProps) {
         <section className="bg-tertiary-fixed py-16 px-6 md:px-12">
           <div className="max-w-7xl mx-auto">
             <div className="bg-primary h-1 w-12 mb-8" />
-            <div id="family-intro" className="max-w-4xl text-on-surface-variant leading-relaxed">
+            <article id="family-intro" className="max-w-4xl text-on-surface-variant leading-relaxed">
               {familyContent.intro}
-            </div>
+            </article>
             <ColorLinkEnhancer containerRef="family-intro" />
           </div>
         </section>
@@ -210,9 +210,9 @@ export default async function ColorFamilyPage({ params }: PageProps) {
       {familyContent?.guide && (
         <section className="py-16 px-6 md:px-12 bg-tertiary-fixed">
           <div className="max-w-7xl mx-auto">
-            <div id="family-guide" className="max-w-4xl text-on-surface-variant">
+            <article id="family-guide" className="max-w-4xl text-on-surface-variant">
               {familyContent.guide}
-            </div>
+            </article>
             <ColorLinkEnhancer containerRef="family-guide" />
           </div>
         </section>

--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -196,6 +196,24 @@ export default async function MatchPage({ params }: PageProps) {
               </Link>
             </div>
 
+            {/* Methodology — gives match pages real, extractable prose (they were
+                ~70 words to content/AI extractors) grounded in the actual pair. */}
+            <article id="match-methodology" className="max-w-3xl mb-12 text-on-surface-variant leading-relaxed">
+              <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-4">How this match is calculated</h2>
+              <p className="mb-4">
+                Every {sourceColor.brand.name} and {targetBrand.name} color in our database is converted to CIELAB coordinates, then scored with the CIEDE2000 formula — the current ISO standard for how different two colors look to the human eye. It corrects for the fact that the eye notices small shifts in some hue ranges far more than others, so it predicts real-world appearance more reliably than comparing hex codes directly.
+              </p>
+              <p>
+                {bestMatch.match_color.name} ranks as the closest {targetBrand.name} equivalent to {sourceColor.name} because it sits nearest in that perceptual space.{" "}
+                {Number(bestMatch.delta_e_score) < 2
+                  ? "The two are near-identical — most people won't read them as different colors once they're on a wall."
+                  : Number(bestMatch.delta_e_score) < 5
+                  ? "The two are very similar — the difference shows side by side but is rarely noticeable across a room."
+                  : "There is a visible difference between them, so treat this as the closest available option rather than an exact dupe."}{" "}
+                Sheen, lighting, and the existing wall color all shift perceived color, so order a sample of {bestMatch.match_color.name} and check it in your actual room before committing.
+              </p>
+            </article>
+
             {targetMatches.length > 1 && (
               <section className="mb-12">
                 <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-6">Other Close Matches in {targetBrand.name}</h2>

--- a/src/lib/color-description.ts
+++ b/src/lib/color-description.ts
@@ -202,12 +202,27 @@ function getPairingSentence(name: string, family: HueFamily): string {
   }
 }
 
-// Saturation modifier appended to pairing sentence. Adds a second axis so
-// hue family × saturation × LRV bucket multiplies the unique tail-string
-// surface ~3x. For achromatic-* families saturation is always "muted" so
-// only that branch fires there.
-function getPairingSaturationModifier(saturation: SaturationBand, isAchromatic: boolean): string {
-  if (isAchromatic) return "";
+// Pairing modifier. Two regimes:
+//  - Chromatic: keyed on saturation band (muted / mid / saturated).
+//  - Achromatic: keyed on LRV/lightness band AND interpolates the color name,
+//    because the 3 base achromatic pairing sentences otherwise collapsed across
+//    ~3,000 pages each. Light/mid/deep neutrals genuinely behave differently, so
+//    this adds a real (not cosmetic) third axis on the largest page segment.
+function getPairingSaturationModifier(
+  saturation: SaturationBand,
+  isAchromatic: boolean,
+  lightness: LightnessCategory,
+  name: string
+): string {
+  if (isAchromatic) {
+    if (lightness === "very light" || lightness === "light") {
+      return ` As a lighter neutral, ${name} works as a whole-room or trim color and keeps adjoining colors reading clean — pair it with crisper whites a step brighter than itself so the trim still separates.`;
+    }
+    if (lightness === "medium") {
+      return ` At mid depth, ${name} grounds a space without darkening it — it holds up on lower walls, kitchen islands, and as a wraparound where a lighter neutral would feel washed out.`;
+    }
+    return ` As a deeper neutral, ${name} reads as a confident anchor — strongest on accent walls, cabinetry, and moody whole rooms that get enough natural light to keep it from going flat.`;
+  }
   if (saturation === "muted") {
     return ` Because this version is on the desaturated side, it pairs forgivingly with both warm and cool accent palettes — and reads especially calm in north-facing rooms where high-chroma versions can feel intrusive.`;
   }
@@ -217,9 +232,24 @@ function getPairingSaturationModifier(saturation: SaturationBand, isAchromatic: 
   return ` At mid saturation, this color sits at a flexible mid-point — bold enough to anchor a room without dominating, and pairs cleanly with both crisp and creamy whites.`;
 }
 
-// Saturation modifier appended to lighting sentence.
-function getLightingSaturationModifier(saturation: SaturationBand, isAchromatic: boolean): string {
-  if (isAchromatic) return "";
+// Lighting modifier — same two regimes as the pairing modifier. The achromatic
+// branch interpolates the name + lightness so the lighting guidance no longer
+// repeats verbatim across thousands of neutral pages.
+function getLightingSaturationModifier(
+  saturation: SaturationBand,
+  isAchromatic: boolean,
+  lightness: LightnessCategory,
+  name: string
+): string {
+  if (isAchromatic) {
+    if (lightness === "very light" || lightness === "light") {
+      return ` Lighter neutrals reveal their undertone most, so ${name} can swing warmer under 2700K bulbs and cleaner under 4000K daylight — sample it against your trim before committing.`;
+    }
+    if (lightness === "medium") {
+      return ` At mid depth ${name} holds its character across bulb temperatures, shifting only slightly warm under 2700K and slightly crisper under cool daylight.`;
+    }
+    return ` Deeper neutrals can read close to black in low light, so preview ${name} in the room's actual evening lighting, not just at midday.`;
+  }
   if (saturation === "muted") {
     return ` Desaturated versions shift least under different lighting — they hold their character whether the room runs warm or cool.`;
   }
@@ -269,23 +299,38 @@ function getQueryTargetingSentences(
   const hex = color.hex.toUpperCase();
   const tempWord = props.temperature === "neutral" ? "neutral" : props.temperature;
 
-  // "What color is X" — directly answers the most common query pattern
-  const whatColorIs = `What color is ${color.name}? It's a ${props.lightness} ${tempWord} ${family} with the hex code ${hex}.`;
+  // Guaranteed-unique lead fact: brand + name + number + hex + LRV + undertone.
+  // Every one of these is per-color data, so this sentence can never collapse to
+  // a near-duplicate across pages. Undertone is stated here (not in a separate
+  // generic callout) and is skipped when it would just echo the temperature word
+  // (avoids "a neutral … neutral undertone").
+  const colorNum = color.color_number ? ` (${color.color_number})` : "";
+  const lrvNum = color.lrv != null ? Math.round(Number(color.lrv)) : null;
+  const lrvClause = lrvNum != null ? `, LRV ${lrvNum}` : "";
+  const undertoneLower = color.undertone ? color.undertone.toLowerCase() : "";
+  const undertoneClause =
+    undertoneLower && undertoneLower !== tempWord ? `, ${undertoneLower} undertone` : "";
+  const whatColorIs = `What color is ${color.brand.name} ${color.name}${colorNum}? It's a ${props.lightness} ${tempWord} ${family} — hex ${hex}${lrvClause}${undertoneClause}.`;
 
-  // "Colors similar to X" — answers "colors similar to" / "colors close to" queries
+  // Nearest cross-brand match — leads with the single closest equivalent (real,
+  // per-color match name) using plain-language closeness, NOT a raw Delta E
+  // number (house rule: Delta E is always shown in words in user-facing copy).
   const closeMatches = matches.filter((m) => Number(m.delta_e_score) < 3).slice(0, 3);
   let similarColors = "";
-  if (closeMatches.length >= 2) {
-    const names = closeMatches.map(
-      (m) => `${m.match_color.brand.name} ${m.match_color.name}`
-    );
-    similarColors = `Colors similar to ${color.name} include ${names.join(", ")}.`;
+  if (closeMatches.length >= 1) {
+    const closest = closeMatches[0];
+    const closestName = `${closest.match_color.brand.name} ${closest.match_color.name}`;
+    const closeness =
+      Number(closest.delta_e_score) < 2 ? "a near-identical match on the wall" : "a very close match";
+    if (closeMatches.length >= 2) {
+      const others = closeMatches
+        .slice(1)
+        .map((m) => `${m.match_color.brand.name} ${m.match_color.name}`);
+      similarColors = `The closest cross-brand equivalent to ${color.name} is ${closestName} — ${closeness}, with ${others.join(" and ")} also close.`;
+    } else {
+      similarColors = `The closest cross-brand equivalent to ${color.name} is ${closestName} — ${closeness}.`;
+    }
   }
-
-  // Undertone callout for "{color} undertones" queries
-  const undertoneCallout = color.undertone
-    ? `${color.name} has a ${color.undertone.toLowerCase()} undertone, which affects how it pairs with trim, flooring, and adjacent wall colors.`
-    : "";
 
   // LRV-driven room application context — adds use-case framing that lifts
   // the description into the 134-167 word citation window the GEO audit
@@ -293,23 +338,22 @@ function getQueryTargetingSentences(
   const lrv = color.lrv != null ? Math.round(Number(color.lrv)) : null;
   const lrvSentence = lrv != null ? getLrvApplicationSentence(color.name, lrv) : "";
 
-  // Trim/hardware pairing — hue family (11) × saturation band (3) for
-  // chromatic colors. Achromatic flavors collapse to the base sentence
-  // since saturation is constant there.
+  // Trim/hardware pairing — chromatic: hue family (11) × saturation (3).
+  // Achromatic: hue flavor (3) × LRV band (3), name-interpolated, so neutrals
+  // no longer share a single pairing tail across thousands of pages.
   const hueFamily = getHueFamily(color, props);
   const pairingSentence =
     getPairingSentence(color.name, hueFamily) +
-    getPairingSaturationModifier(props.saturation, props.isAchromatic);
+    getPairingSaturationModifier(props.saturation, props.isAchromatic, props.lightness, color.name);
 
-  // Lighting-behavior guidance — same hue × saturation composition.
+  // Lighting-behavior guidance — same composition.
   const lightingSentence =
     getLightingBehaviorSentence(color.name, hueFamily) +
-    getLightingSaturationModifier(props.saturation, props.isAchromatic);
+    getLightingSaturationModifier(props.saturation, props.isAchromatic, props.lightness, color.name);
 
   return [
     whatColorIs,
     similarColors,
-    undertoneCallout,
     lrvSentence,
     pairingSentence,
     lightingSentence,


### PR DESCRIPTION
## Why
The audit's root-cause finding: ~23K thin, near-duplicate programmatic color descriptions triggered + sustain the HCU demotion and starve Google crawl/indexation of the dominant page type. This PR is the **Critical + High content-system work** that actually moves recovery (the quick wins in #91 were the periphery).

## Changes
**C1 — `src/lib/color-description.ts`**
- Enriched guaranteed-unique lead fact: brand + name + number + hex + LRV + undertone.
- "Similar colors" → leads with the single closest cross-brand equivalent by name, **plain-language closeness (no raw Delta E)**.
- Split achromatic **pairing + lighting** branches by LRV band + interpolate the color name — fixes the worst collapse (3 achromatic lighting sentences had appeared verbatim across ~3,000 neutral pages each).
- Dropped the duplicate generic undertone tail (undertone now in the lead).

**H1 — `<div>` → `<article>`** on family intro+guide and brand intro+details. Extractors saw ~76 words (treated as boilerplate chrome); now they see the full 400+ words. Helps content-quality signal *and* GEO citeability.

**Match pages** — added a ~140-word CIEDE2000 methodology `<article>` grounded in the actual color pair (plain-language verdict). Match pages were ~70 words to extractors.

## Verification
Ran the generator over an **800-color achromatic sample** (worst case), conservatively with `matches=[]`:

| Metric | Result |
|---|---|
| Distinct skeletons | **119** |
| Largest skeleton cluster | **40 pages / 5.0%** (audit had 200+) |
| Short (<25-word) descriptions | 0 |

Understated twice over: the metric masks LRV numbers (visibly differ per page) and excludes the nearest-match sentence (makes production copy essentially all-unique). Net description length unchanged.

- [x] `tsc` clean on all 4 changed `src/` files (only the pre-existing, `.vercelignore`d `scripts/*.tsx` noise remains).
- [x] `seo-preflight`: GO — no AI-slop, no raw Delta E, additive content, no schema/page changes.
- [ ] Vercel preview build (authoritative gate).

No new pages, no schema change; ISR propagates gradually. Audit: `seo-audits/2026-06-03-full-audit/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)