### PR TITLE
seo(medium-batch): Product image, brand FAQ, sitemap freshness, reciprocal links

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,12 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // Frozen at build time (this file evaluates once per build) so sitemap
+  // lastmod values reflect the actual deploy date instead of resetting to
+  // "today" on every ISR cold-start — which Googlebot reads as false freshness.
+  env: {
+    SITE_BUILD_DATE: new Date().toISOString().split("T")[0],
+  },
   // Suppress the X-Powered-By: Next.js fingerprinting header.
   poweredByHeader: false,
   htmlLimitedBots:

--- a/src/app/api/sitemap/[id]/route.ts
+++ b/src/app/api/sitemap/[id]/route.ts
@@ -16,7 +16,13 @@ const COLORS_PER_SITEMAP = 5000;
 // starts this is effectively "deploy time," which is what we want
 // Googlebot to see as the recency signal. Blog posts use their own
 // post.date and override this.
-const SITE_BUILD_DATE = new Date().toISOString().split("T")[0];
+//
+// Frozen at build time via next.config.ts `env` so it reflects the actual
+// deploy date instead of resetting to "today" on every hourly ISR cold-start
+// (uniform "updated today" across thousands of URLs reads as false freshness
+// and erodes Googlebot's crawl-scheduling trust). Falls back to runtime date.
+const SITE_BUILD_DATE =
+  process.env.SITE_BUILD_DATE ?? new Date().toISOString().split("T")[0];
 
 interface SitemapEntry {
   url: string;

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from "next/server";
 import { getAllColorSlugs } from "@/lib/queries";
-import { getAllBlogSlugs } from "@/lib/blog-posts";
+import { getAllBlogSlugs, getAllPosts } from "@/lib/blog-posts";
 
 // ISR: refresh hourly so a scheduled post enters the sitemap index on its date.
 export const revalidate = 3600;
 
 const BASE_URL = "https://www.paintcolorhq.com";
 const COLORS_PER_SITEMAP = 5000;
+
+// Build-time deploy date (frozen via next.config.ts `env`) — index lastmod for
+// static shards, so it doesn't reset to "today" each ISR cycle (false freshness).
+const SITE_BUILD_DATE =
+  process.env.SITE_BUILD_DATE ?? new Date().toISOString().split("T")[0];
 
 export async function GET() {
   try {
@@ -31,12 +36,22 @@ export async function GET() {
       if (idx !== -1) sitemapNames.splice(idx, 1);
     }
 
+    // The blog shard's lastmod is the most-recent live post date (real
+    // freshness); every other shard uses the frozen deploy date.
+    const livePosts = getAllPosts();
+    const blogLastmod =
+      livePosts.length > 0
+        ? livePosts.map((p) => p.date).sort().at(-1)!
+        : SITE_BUILD_DATE;
+    const lastmodFor = (name: string) => (name === "blog" ? blogLastmod : SITE_BUILD_DATE);
+
     const sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${sitemapNames
   .map(
     (name) => `  <sitemap>
     <loc>${BASE_URL}/sitemap/${name}.xml</loc>
+    <lastmod>${lastmodFor(name)}</lastmod>
   </sitemap>`
   )
   .join("\n")}

--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -137,6 +137,30 @@ export default async function BrandPage({ params }: PageProps) {
 
   const brandContent = getBrandContent(brand.slug);
   const subtitle = brandContent?.subtitle ?? `Browse every ${brand.name} color with undertone tags, LRV values, and cross-brand matches`;
+
+  // Data-grounded FAQ (rendered visibly below + as FAQPage schema). Brand pages
+  // are the biggest impression earner; visible FAQ adds SERP/AI surface. Answers
+  // vary per brand (count, most-searched colors, match targets) so they aren't
+  // templated. Rendered in the DOM because JSON-LD-only FAQ gets ignored.
+  const matchTargetNames = matchTargets.slice(0, 3).map((t) => t.name);
+  const brandFaqs: { q: string; a: string }[] = [
+    {
+      q: `How many ${brand.name} paint colors are there?`,
+      a: `${brand.name} has ${brand.color_count.toLocaleString()} paint colors catalogued on Paint Color HQ, each listed with its hex code, RGB values, LRV, and undertone.`,
+    },
+    ...(popularColors.length >= 3
+      ? [{
+          q: `What are the most popular ${brand.name} paint colors?`,
+          a: `Among the most-searched ${brand.name} colors on Paint Color HQ are ${popularColors.slice(0, 3).map((c) => c.name).join(", ")} — ranked by cross-brand match demand rather than marketing.`,
+        }]
+      : []),
+    ...(matchTargetNames.length >= 2
+      ? [{
+          q: `Can I match ${brand.name} colors to other brands?`,
+          a: `Yes. Every ${brand.name} color has its closest equivalents in ${matchTargetNames.join(", ")} and other brands, computed with the CIEDE2000 color-difference formula so the matches reflect how similar the colors actually look.`,
+        }]
+      : []),
+  ];
   const orgData = brandOrgData[brand.slug];
 
   return (
@@ -332,6 +356,24 @@ export default async function BrandPage({ params }: PageProps) {
         );
       })()}
 
+      {/* FAQ — rendered visibly (JSON-LD-only FAQ gets ignored) + FAQPage schema below */}
+      {brandFaqs.length > 0 && (
+        <section className="max-w-4xl mx-auto px-6 md:px-12 py-16">
+          <h2 className="font-headline text-3xl font-bold text-on-surface tracking-tight mb-8">{brand.name} colors — frequently asked</h2>
+          <div className="space-y-3">
+            {brandFaqs.map((f) => (
+              <details key={f.q} className="group rounded-xl border border-outline-variant/10 bg-surface-container-lowest p-5">
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-headline font-bold text-on-surface">
+                  {f.q}
+                  <span className="text-outline transition-transform group-open:rotate-180">&#9662;</span>
+                </summary>
+                <p className="mt-3 text-on-surface-variant leading-relaxed">{f.a}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* JSON-LD */}
       <JsonLd data={{
         "@context": "https://schema.org", "@type": "CollectionPage",
@@ -353,6 +395,13 @@ export default async function BrandPage({ params }: PageProps) {
         ...(orgData.foundingDate && { foundingDate: orgData.foundingDate }),
         ...(orgData.headquarters && { address: { "@type": "PostalAddress", addressLocality: orgData.headquarters } }),
         ...(orgData.sameAs && orgData.sameAs.length > 0 && { sameAs: orgData.sameAs }),
+      }} />}
+      {brandFaqs.length > 0 && <JsonLd data={{
+        "@context": "https://schema.org", "@type": "FAQPage",
+        mainEntity: brandFaqs.map((f) => ({
+          "@type": "Question", name: f.q,
+          acceptedAnswer: { "@type": "Answer", text: f.a },
+        })),
       }} />}
 
       <AdSenseScript />

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -532,6 +532,9 @@ export default async function ColorPage({ params }: PageProps) {
         name: `${color.name}${color.color_number ? ` ${color.color_number}` : ""}`,
         description: description,
         url: `https://www.paintcolorhq.com/colors/${brandSlug}/${colorSlug}`,
+        // Recommended for Product rich results — reuse the generated swatch OG
+        // image so color pages are eligible for image-enriched SERP formats.
+        image: `https://www.paintcolorhq.com/api/og?hex=${encodeURIComponent(color.hex)}&name=${encodeURIComponent(color.name)}&brand=${encodeURIComponent(color.brand.name)}`,
         ...(color.color_number ? { sku: color.color_number, mpn: color.color_number } : {}),
         color: color.hex.toUpperCase(),
         brand: { "@type": "Brand", name: color.brand.name },

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -8,6 +8,7 @@ import { FamilyColorLibrary } from "@/components/family-color-library";
 import { FamilyColorLibraryFallback } from "@/components/family-color-library-fallback";
 import { getColorsByFamily, getColorsByFamilyCount, getAllBrands } from "@/lib/queries";
 import { getFamilyContent, getFamilyRelatedPalettes } from "@/lib/family-content";
+import { getPostsByFamily } from "@/lib/blog-posts";
 import { FAMILY_UNDERTONE_ANSWERS } from "@/lib/family-undertone-copy";
 import { getPaletteBySlug } from "@/lib/palettes";
 import { TrackPage } from "@/components/track-page";
@@ -81,6 +82,9 @@ export default async function ColorFamilyPage({ params }: PageProps) {
 
   const familyName = capitalize(familySlug.replace(/-/g, " "));
   const familyContent = getFamilyContent(familySlug);
+  // Reciprocal family→blog links — close the one-way link gap the cluster audit
+  // flagged (round-up posts link into family pages but not back).
+  const relatedPosts = getPostsByFamily(familySlug);
   const brandCount = brands.length;
   const baseUrl = `https://www.paintcolorhq.com/colors/family/${familySlug}`;
   const fc = familyColors[familySlug] ?? { hex: "#9CA3AF" };
@@ -214,6 +218,25 @@ export default async function ColorFamilyPage({ params }: PageProps) {
               {familyContent.guide}
             </article>
             <ColorLinkEnhancer containerRef="family-guide" />
+          </div>
+        </section>
+      )}
+
+      {/* Related reading — reciprocal links to the family's round-up posts */}
+      {relatedPosts.length > 0 && (
+        <section className="py-16 px-6 md:px-12 bg-surface">
+          <div className="max-w-7xl mx-auto">
+            <h2 className="font-headline text-2xl font-bold text-on-surface tracking-tight mb-6">Related reading</h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {relatedPosts.map((post) => (
+                <Link key={post.slug} href={`/blog/${post.slug}`}
+                  className="group block rounded-xl border border-outline-variant/10 bg-surface-container-lowest p-6 hover:shadow-lg transition-all">
+                  <h3 className="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">{post.title}</h3>
+                  <p className="mt-2 text-sm text-on-surface-variant line-clamp-2">{post.excerpt}</p>
+                  <span className="mt-4 inline-flex items-center gap-1 text-primary font-bold text-sm group-hover:gap-2 transition-all">Read the guide <span>&rarr;</span></span>
+                </Link>
+              ))}
+            </div>
           </div>
         </section>
       )}

--- a/src/lib/blog-posts.tsx
+++ b/src/lib/blog-posts.tsx
@@ -3926,11 +3926,46 @@ export function getPostsByBrand(brandName: string, limit = 3): BlogPost[] {
 
   const matches = blogPosts.filter((p) => {
     if (!isLive(p.date)) return false;
-    const searchable = `${p.title} ${p.excerpt} ${p.tags.join(" ")}`.toLowerCase();
+    // Match on title + tags only (not excerpt) — a post genuinely about a brand
+    // names it in one of those. Excerpt matching pulled in OTHER brands' posts
+    // that merely mention this brand in a cross-brand comparison (e.g. a
+    // Dunn-Edwards round-up surfacing on /brands/behr).
+    const searchable = `${p.title} ${p.tags.join(" ")}`.toLowerCase();
     return terms.some((t) => searchable.includes(t));
   });
 
-  // Sort newest first
-  matches.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  // THIS brand's own general round-up ranks first — the right primary companion
+  // for a brand page over a room-specific post. It's identified by the "Brand"
+  // tag AND a tag matching the brand itself (so a *different* brand's round-up
+  // that merely mentions this brand in its body isn't wrongly promoted). Then
+  // newest first. (Cluster audit flagged the wrong post leading on /brands/behr.)
+  const isOwnRoundup = (p: BlogPost) =>
+    p.tags.includes("Brand") && p.tags.some((t) => terms.includes(t.toLowerCase()));
+  matches.sort((a, b) => {
+    const rank = (isOwnRoundup(b) ? 1 : 0) - (isOwnRoundup(a) ? 1 : 0);
+    if (rank !== 0) return rank;
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
+  return matches.slice(0, limit);
+}
+
+// Live posts associated with a color family, for reciprocal family→blog links
+// (family pages historically linked nowhere back to their round-up posts —
+// cluster audit finding). Matches the capitalized family name as a tag, or a
+// "{family} paint colors" phrase in the title. Round-up "Guide" posts first.
+export function getPostsByFamily(familySlug: string, limit = 2): BlogPost[] {
+  const fam = familySlug.toLowerCase();
+  const famCap = fam.charAt(0).toUpperCase() + fam.slice(1);
+  const matches = blogPosts.filter((p) => {
+    if (!isLive(p.date)) return false;
+    const titleHasFamily = p.title.toLowerCase().includes(`${fam} paint colors`);
+    return p.tags.includes(famCap) || titleHasFamily;
+  });
+  matches.sort((a, b) => {
+    const aGuide = a.tags.includes("Guide") ? 1 : 0;
+    const bGuide = b.tags.includes("Guide") ? 1 : 0;
+    if (aGuide !== bGuide) return bGuide - aGuide;
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
   return matches.slice(0, limit);
 }


### PR DESCRIPTION
## Summary
The Medium-tier audit fixes (2026-06-03) in one batch.

| # | Fix | File(s) |
|---|-----|---------|
| **M4** | `image` (existing `/api/og` swatch) added to color-page Product JSON-LD → ~23K pages eligible for image-rich results | `colors/[brandSlug]/[colorSlug]/page.tsx` |
| **M5** | Brand pages get a **visible FAQ accordion + FAQPage schema** (data-grounded per brand: count, most-searched, cross-brand matching). DOM-rendered because JSON-LD-only FAQ is ignored. Brand pages are the top GSC impression earner. | `brands/[brandSlug]/page.tsx` |
| **M6** | `SITE_BUILD_DATE` frozen at **build time** via `next.config.ts env` (was resetting to "today" each ISR cold-start = false freshness); `<lastmod>` added to sitemap-index children (blog = latest live-post date). | `next.config.ts`, `api/sitemap/route.ts`, `api/sitemap/[id]/route.ts` |
| **M7** | Reciprocal blog↔family links (`getPostsByFamily` + "Related reading" on family pages); fixed `getPostsByBrand` to match brand in **title+tags only** (stops a Dunn-Edwards round-up bleeding onto `/brands/behr`) and rank a brand's **own** round-up first. | `blog-posts.tsx`, `colors/family/[familySlug]/page.tsx` |

## Verification
- [x] `tsc` clean on all 7 files.
- [x] Runtime-checked `getPostsByBrand`/`getPostsByFamily`: Valspar leads with its own round-up, Behr no longer shows the DE post, family→blog links resolve (blue→best-blue, white→both white posts).
- [x] `seo-preflight`: GO.
- [ ] Vercel preview build.

Deferred: per-color `updated_at` DB column (migration — separate change). No new pages; ISR propagates gradually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)