### PR TITLE
seo(low): drop redundant X-Frame-Options + color-identifier title differentiator

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,10 +22,8 @@ const securityHeaders = [
     key: "Content-Security-Policy",
     value: contentSecurityPolicy,
   },
-  {
-    key: "X-Frame-Options",
-    value: "SAMEORIGIN",
-  },
+  // X-Frame-Options removed — the CSP `frame-ancestors 'self'` directive is the
+  // modern equivalent and supersedes it in all current browsers.
   {
     key: "X-Content-Type-Options",
     value: "nosniff",

--- a/src/app/tools/color-identifier/page.tsx
+++ b/src/app/tools/color-identifier/page.tsx
@@ -7,7 +7,7 @@ import { AdSenseScript } from "@/components/adsense-script";
 import { ToolCrossSell } from "@/components/tool-cross-sell";
 
 export const metadata: Metadata = {
-  title: "Photo Color Identifier - Find Paint Colors from Photos",
+  title: "Photo Color Identifier: Match to 14 Brands",
   description:
     "Upload a photo and click any spot to find matching paint colors from Sherwin-Williams, Benjamin Moore, Behr, and more. Free, instant, cross-brand results.",
   alternates: {


### PR DESCRIPTION
## Summary
Two trivial Low-tier audit items.

- **L2** — Remove the `X-Frame-Options: SAMEORIGIN` header. The CSP `frame-ancestors 'self'` directive (already present) is the modern equivalent and supersedes it in all current browsers; also clears a false-positive flag in security scanners.
- **L3** — Color Identifier `<title>` now leads with the multi-brand differentiator: `Photo Color Identifier: Match to 14 Brands` (59 chars with the ` | Paint Color HQ` template — the old title was 71). Differentiates from single-brand native apps (ColorSnap, BM Color Portfolio) that rank above it on-device. The intro/H1 already led with "23,000+ colors across 14 brands," so no copy change needed there.

## Verification
- [x] `tsc` clean.
- [x] Title length 59 chars with template.
- [ ] Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)