### PR TITLE
seo(postfix-lows): color-identifier H1 + accurate brand color count

### DIFF
--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -36,7 +36,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { brandSlug } = await params;
   const brand = await getBrandBySlug(brandSlug);
   if (!brand) return { title: "Brand Not Found" };
-  const count = brand.color_count.toLocaleString();
+  // Live count, not the stored brand.color_count (which is stale — undercounts
+  // the actual indexable color pages; the grid, sitemap, and schema all use the
+  // live count, so display + title must too).
+  const count = (await getColorsByBrandCount(brand.id)).toLocaleString();
   const url = `https://www.paintcolorhq.com/brands/${brandSlug}`;
   // Lead with "[Brand] Color Chart" + "all [count] colors" — the two big
   // under-captured Bing queries (the page already ranks pos 3-8 for them).
@@ -146,7 +149,7 @@ export default async function BrandPage({ params }: PageProps) {
   const brandFaqs: { q: string; a: string }[] = [
     {
       q: `How many ${brand.name} paint colors are there?`,
-      a: `${brand.name} has ${brand.color_count.toLocaleString()} paint colors catalogued on Paint Color HQ, each listed with its hex code, RGB values, LRV, and undertone.`,
+      a: `${brand.name} has ${totalCount.toLocaleString()} paint colors catalogued on Paint Color HQ, each listed with its hex code, RGB values, LRV, and undertone.`,
     },
     ...(popularColors.length >= 3
       ? [{
@@ -180,7 +183,7 @@ export default async function BrandPage({ params }: PageProps) {
           </nav>
 
           <span className="text-[10px] uppercase tracking-[0.2em] text-secondary font-bold mb-4 block">
-            {brand.color_count.toLocaleString()} Colors
+            {totalCount.toLocaleString()} Colors
             {orgData?.foundingDate && ` \u00B7 Est. ${orgData.foundingDate}`}
             {orgData?.headquarters && ` \u00B7 ${orgData.headquarters}`}
           </span>
@@ -292,7 +295,7 @@ export default async function BrandPage({ params }: PageProps) {
         <div className="max-w-7xl mx-auto">
           <div className="mb-10">
             <h2 className="font-headline text-3xl font-bold tracking-tight text-on-surface">
-              All {brand.color_count.toLocaleString()} {brand.name} Colors
+              All {totalCount.toLocaleString()} {brand.name} Colors
             </h2>
             <p className="mt-2 text-on-surface-variant max-w-2xl leading-relaxed">
               The complete {brand.name} color chart — every shade with its hex code, LRV, and undertone. Filter by family or search, and open any color for its cross-brand matches.
@@ -378,7 +381,7 @@ export default async function BrandPage({ params }: PageProps) {
       <JsonLd data={{
         "@context": "https://schema.org", "@type": "CollectionPage",
         name: `${brand.name} Color Chart`,
-        description: `The complete ${brand.name} color chart — all ${brand.color_count.toLocaleString()} ${brand.name} colors with hex codes, RGB values, LRV, and cross-brand matches.`,
+        description: `The complete ${brand.name} color chart — all ${totalCount.toLocaleString()} ${brand.name} colors with hex codes, RGB values, LRV, and cross-brand matches.`,
         url: `https://www.paintcolorhq.com/brands/${brand.slug}`,
         breadcrumb: { "@type": "BreadcrumbList", itemListElement: [
           { "@type": "ListItem", position: 1, name: "Home", item: "https://www.paintcolorhq.com" },

--- a/src/app/tools/color-identifier/page.tsx
+++ b/src/app/tools/color-identifier/page.tsx
@@ -54,7 +54,7 @@ export default function ColorIdentifierPage() {
         <div className="max-w-7xl mx-auto">
           <span className="text-primary font-bold text-xs uppercase tracking-widest">Tool</span>
           <h1 className="font-headline text-5xl md:text-6xl font-extrabold tracking-tighter text-on-surface leading-[0.9] mt-2 mb-4">
-            Photo Color Identifier
+            Photo Color Identifier <span className="text-primary">— Match Across 14 Brands</span>
           </h1>
           <p className="text-lg text-on-surface-variant max-w-xl leading-relaxed">
             Upload any photo and click a spot to find the closest matching paint


### PR DESCRIPTION
## Summary
The two quick LOWs surfaced by the post-fix audit.

- **L4 — Color Identifier H1:** now carries the multi-brand differentiator (`— Match Across 14 Brands`); previously only the `<title>` had it, the visible H1 was just "Photo Color Identifier."
- **L3 — Accurate brand color count:** brand pages now display the **live count** (`totalCount`) in the title, meta description, hero, "All N colors" H2, and FAQ — instead of the stored `brand.color_count`.

### Why the count change (verified)
`brand.color_count` for Sherwin-Williams said **1,527**, but a definitive uncapped query found **1,731 distinct color slugs, zero duplicates** — the stored field is stale by 204 real, indexable pages. The grid, sitemap, and the CollectionPage `numberOfItems` already used the live count, so the **display was the wrong one**. This aligns the whole brand page to one accurate source of truth (resolves the schema-vs-display mismatch the audit flagged — correctly, by fixing the display rather than enshrining the stale number in schema).

**Follow-up noted (not in this PR):** the `brands.color_count` column is stale catalog-wide — a data-layer update to live counts is the proper single-source fix. Brand-page display no longer depends on it either way.

## Verification
- [x] `tsc` clean on both files; no remaining `brand.color_count` display usages.
- [ ] Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)