### PR TITLE
content(sxo): curated editorial batch 5 — +14 (62 total)

### DIFF
--- a/docs/superpowers/content/research/editorial-batch5.md
+++ b/docs/superpowers/content/research/editorial-batch5.md
@@ -1,0 +1,264 @@
+# Research: Editorial batch 5
+
+> Verified from the PaintColorHQ database on 2026-06-04. Every hex, LRV, undertone, and cross-brand match below is first-party data. Cite these values exactly; do not invent or round them.
+
+## Shoji White — Sherwin-Williams (7042)
+- Hex: #e6dfd3 | LRV: 74.3 | Undertone: Neutral | Family: orange
+- URL: /colors/sherwin-williams/shoji-white-7042
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Crisp Linen | #e6dfd2 | 0.4 | /colors/behr/crisp-linen-mq3-13 |
+| Benjamin Moore | Etiquette | #e6e1d6 | 1.0 | /colors/benjamin-moore/etiquette-af-50 |
+| Colorhouse | Bisque .03 | #e4e2d3 | 3.1 | /colors/colorhouse/bisque-03-bisque-03 |
+| Dunn-Edwards | Crisp Muslin | #e9e2d7 | 0.8 | /colors/dunn-edwards/crisp-muslin-de6212 |
+| Dutch Boy | Dove White | #e9e6df | 2.9 | /colors/dutch-boy/dove-white-dcp-0018 |
+| Farrow & Ball | School House White | #e6dfd1 | 0.9 | /colors/farrow-ball/school-house-white-291 |
+| Hirshfield's | Herare White | #e7e0d3 | 0.5 | /colors/hirshfields/herare-white-215 |
+| Kilz | Antique White | #e9e2d8 | 1.2 | /colors/kilz/antique-white-lj220 |
+| PPG | Water Chestnut | #e8e1d5 | 0.4 | /colors/ppg/water-chestnut-1078-2 |
+| Valspar | Totten's Inlet | #e8e2d6 | 0.8 | /colors/valspar/tottens-inlet-7006-9 |
+| Vista Paint | August Moon | #e5dfd4 | 0.5 | /colors/vista-paint/august-moon-c-193 |
+
+## Modern Gray — Sherwin-Williams (7632)
+- Hex: #d6cec3 | LRV: 62.4 | Undertone: Neutral | Family: beige
+- URL: /colors/sherwin-williams/modern-gray-7632
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Mineral | #d7d0c6 | 0.7 | /colors/behr/mineral-ul170-15 |
+| Benjamin Moore | Rocking Chair | #d6ccbf | 1.1 | /colors/benjamin-moore/rocking-chair-csp-400 |
+| Dunn-Edwards | Fine Grain | #d8cfc1 | 1.3 | /colors/dunn-edwards/fine-grain-de6213 |
+| Dutch Boy | Lady Nicole | #ddddd5 | 5.0 | /colors/dutch-boy/lady-nicole-dcp-0030 |
+| Farrow & Ball | Cornforth White | #d1cbc3 | 1.6 | /colors/farrow-ball/cornforth-white-228 |
+| Hirshfield's | Mossy Shade | #dbd2c7 | 1.1 | /colors/hirshfields/mossy-shade-195 |
+| Kilz | Starched Linen | #dad2c7 | 1.0 | /colors/kilz/starched-linen-lk210 |
+| MPC | Metro Gray | #cecac0 | 2.2 | /colors/mpc/metro-gray-mp7425 |
+| PPG | Gray Beige | #dad1c6 | 0.9 | /colors/ppg/gray-beige-14-30 |
+| Valspar | Heritage Gray | #d1cbc1 | 1.2 | /colors/valspar/heritage-gray-7007-24 |
+| Vista Paint | Grey Ghost | #d3cbbf | 0.9 | /colors/vista-paint/grey-ghost-k-957 |
+
+## Useful Gray — Sherwin-Williams (7050)
+- Hex: #cfcabd | LRV: 59.2 | Undertone: Neutral | Family: beige
+- URL: /colors/sherwin-williams/useful-gray-7050
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Coliseum Marble | #cec7b8 | 1.3 | /colors/behr/coliseum-marble-ppu8-16 |
+| Benjamin Moore | Revere Pewter | #ccc7b9 | 0.9 | /colors/benjamin-moore/revere-pewter-hc-172 |
+| Colorhouse | Stone .04 | #c9cabd | 3.0 | /colors/colorhouse/stone-04-stone-04 |
+| Dunn-Edwards | Porous Stone | #d4cebf | 1.3 | /colors/dunn-edwards/porous-stone-de6220 |
+| Farrow & Ball | Cromarty | #cfcec0 | 2.3 | /colors/farrow-ball/cromarty-285 |
+| Hirshfield's | Desert Mirage | #d2cabc | 1.4 | /colors/hirshfields/desert-mirage-231 |
+| Kilz | Smoke Ring | #c9c7be | 2.1 | /colors/kilz/smoke-ring-rk100 |
+| MPC | Brightray Silver Met. | #d2cdbe | 1.1 | /colors/mpc/brightray-silver-met-mp18082 |
+| PPG | Storm's Coming | #cfc9bc | 0.6 | /colors/ppg/storms-coming-1008-2 |
+| RAL | Silk Grey | #cac4b0 | 3.2 | /colors/ral/silk-grey-7044 |
+| Valspar | Villa Grey | #d1ccbf | 0.5 | /colors/valspar/villa-grey-6005-1b |
+| Vista Paint | Hidden Cove | #cdc7bb | 1.0 | /colors/vista-paint/hidden-cove-c-209 |
+
+## Anew Gray — Sherwin-Williams (7030)
+- Hex: #bfb6aa | LRV: 47.4 | Undertone: Neutral | Family: gray
+- URL: /colors/sherwin-williams/anew-gray-7030
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Grey Mist | #beb7ae | 1.4 | /colors/behr/grey-mist-hdc-ct-21 |
+| Benjamin Moore | Silver Fox | #b9b2a8 | 1.6 | /colors/benjamin-moore/silver-fox-2108-50 |
+| Dunn-Edwards | Drifting | #beb4a8 | 0.7 | /colors/dunn-edwards/drifting-dec770 |
+| Dutch Boy | Drifting Sand | #b6b2a9 | 2.8 | /colors/dutch-boy/drifting-sand-dcp-0218 |
+| Farrow & Ball | Purbeck Stone | #c4beb4 | 2.5 | /colors/farrow-ball/purbeck-stone-275 |
+| Hirshfield's | Light Lichen | #bfb6a9 | 0.5 | /colors/hirshfields/light-lichen-211 |
+| Kilz | Urban Gateway | #bcb5a9 | 1.1 | /colors/kilz/urban-gateway-lk110 |
+| MPC | Platinum Met. | #c1b7aa | 0.6 | /colors/mpc/platinum-met-mp20083 |
+| PPG | Silver Dollar | #bdb6ae | 1.8 | /colors/ppg/silver-dollar-1022-3 |
+| Valspar | Luxe Gray | #bfb6aa | 0.0 | /colors/valspar/luxe-gray-8005-4c |
+| Vista Paint | Light Lichen | #bfb7a9 | 1.2 | /colors/vista-paint/light-lichen-c-210 |
+
+## Amazing Gray — Sherwin-Williams (7044)
+- Hex: #beb5a9 | LRV: 46.9 | Undertone: Neutral | Family: gray
+- URL: /colors/sherwin-williams/amazing-gray-7044
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Grey Mist | #beb7ae | 1.5 | /colors/behr/grey-mist-hdc-ct-21 |
+| Benjamin Moore | Silver Fox | #b9b2a8 | 1.4 | /colors/benjamin-moore/silver-fox-2108-50 |
+| Dunn-Edwards | Drifting | #beb4a8 | 0.6 | /colors/dunn-edwards/drifting-dec770 |
+| Dutch Boy | Drifting Sand | #b6b2a9 | 2.7 | /colors/dutch-boy/drifting-sand-dcp-0218 |
+| Farrow & Ball | Purbeck Stone | #c4beb4 | 2.7 | /colors/farrow-ball/purbeck-stone-275 |
+| Hirshfield's | Light Lichen | #bfb6a9 | 0.5 | /colors/hirshfields/light-lichen-211 |
+| Kilz | Urban Gateway | #bcb5a9 | 1.0 | /colors/kilz/urban-gateway-lk110 |
+| MPC | Platinum Met. | #c1b7aa | 0.8 | /colors/mpc/platinum-met-mp20083 |
+| PPG | Silver Dollar | #bdb6ae | 1.8 | /colors/ppg/silver-dollar-1022-3 |
+| Valspar | Luxe Gray | #bfb6aa | 0.3 | /colors/valspar/luxe-gray-8005-4c |
+| Vista Paint | Light Lichen | #bfb7a9 | 1.3 | /colors/vista-paint/light-lichen-c-210 |
+
+## Natural Linen — Benjamin Moore (966)
+- Hex: #d8ceb8 | LRV: 59.8 | Undertone: Neutral | Family: beige
+- URL: /colors/benjamin-moore/natural-linen-966
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Bell Tower | #d9cdb7 | 1.0 | /colors/behr/bell-tower-mq3-15 |
+| Colorhouse | Stone .01 | #e1d6bb | 2.5 | /colors/colorhouse/stone-01-stone-01 |
+| Dunn-Edwards | Nomadic Taupe | #d2c6ae | 2.1 | /colors/dunn-edwards/nomadic-taupe-de6192 |
+| Farrow & Ball | Off-White | #e0d5be | 1.8 | /colors/farrow-ball/off-white-3 |
+| Hirshfield's | Velum Smoke | #d6ceb9 | 0.9 | /colors/hirshfields/velum-smoke-342 |
+| Kilz | Pale Gold | #dcd0b8 | 1.1 | /colors/kilz/pale-gold-lk240 |
+| MPC | Sunrise Silver Metallic | #dbd2b8 | 1.9 | /colors/mpc/sunrise-silver-metallic-mp55753 |
+| PPG | Toasted Almond | #dacfba | 0.8 | /colors/ppg/toasted-almond-1097-3 |
+| RAL | Silk Grey | #cac4b0 | 3.2 | /colors/ral/silk-grey-7044 |
+| Sherwin-Williams | Wool Skein | #d9cfba | 0.5 | /colors/sherwin-williams/wool-skein-6148 |
+| Valspar | Rattan Basket | #dacfbb | 1.1 | /colors/valspar/rattan-basket-3007-10c |
+| Vista Paint | Velum Smoke | #d5cdb8 | 1.0 | /colors/vista-paint/velum-smoke-c-341 |
+
+## White Heron — Sherwin-Williams (7627)
+- Hex: #e7e1d7 | LRV: 75.7 | Undertone: Neutral | Family: orange
+- URL: /colors/sherwin-williams/white-heron-7627
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Cinnamon Cake (w-f-220) | #e8e2d7 | 0.5 | /colors/behr/cinnamon-cake-w-f-220-w-f-220 |
+| Benjamin Moore | Etiquette | #e6e1d6 | 0.8 | /colors/benjamin-moore/etiquette-af-50 |
+| Colorhouse | Imagine .06 | #eae9e1 | 2.9 | /colors/colorhouse/imagine-06-imagine-06 |
+| Dunn-Edwards | Crisp Muslin | #e9e2d7 | 0.6 | /colors/dunn-edwards/crisp-muslin-de6212 |
+| Dutch Boy | Dove White | #e9e6df | 2.0 | /colors/dutch-boy/dove-white-dcp-0018 |
+| Farrow & Ball | School House White | #e6dfd1 | 1.7 | /colors/farrow-ball/school-house-white-291 |
+| Hirshfield's | August Moon | #e5e0d5 | 0.8 | /colors/hirshfields/august-moon-194 |
+| Kilz | Reserved White | #e6e1d8 | 0.6 | /colors/kilz/reserved-white-tb-07 |
+| PPG | Indian Muslin | #eae3d8 | 0.7 | /colors/ppg/indian-muslin-1075-2 |
+| Valspar | Totten's Inlet | #e8e2d6 | 0.9 | /colors/valspar/tottens-inlet-7006-9 |
+| Vista Paint | Lamb's Wool | #e8e2d9 | 0.5 | /colors/vista-paint/lambs-wool-k-1183 |
+
+## Sleepy Blue — Sherwin-Williams (6225)
+- Hex: #bccbce | LRV: 57.9 | Undertone: Neutral | Family: neutral
+- URL: /colors/sherwin-williams/sleepy-blue-6225
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | High Speed Access | #bdccd1 | 1.1 | /colors/behr/high-speed-access-n530-3 |
+| Benjamin Moore | Smoke | #bbc9ca | 1.1 | /colors/benjamin-moore/smoke-2122-40 |
+| Colorhouse | Wool .02 | #c1cdcd | 1.8 | /colors/colorhouse/wool-02-wool-02 |
+| Dunn-Edwards | Mount Sterling | #cad3d4 | 3.2 | /colors/dunn-edwards/mount-sterling-de6317 |
+| Dutch Boy | Laguna White | #c8cdc9 | 4.9 | /colors/dutch-boy/laguna-white-7411 |
+| Farrow & Ball | Parma Gray | #b2bfc5 | 3.5 | /colors/farrow-ball/parma-gray-27 |
+| Hirshfield's | Tudor Ice | #c1cecf | 1.4 | /colors/hirshfields/tudor-ice-historic-tudor-ice |
+| Kilz | Wild Arctic | #bfcbcb | 1.6 | /colors/kilz/wild-arctic-re210-02 |
+| MPC | Deepsea Spray | #c3ced3 | 2.4 | /colors/mpc/deepsea-spray-mp745 |
+| PPG | Scandinavian Sky | #c2d3d6 | 2.0 | /colors/ppg/scandinavian-sky-1149-3 |
+| Valspar | Milky Way | #bfcbcd | 1.1 | /colors/valspar/milky-way-8004-37b |
+| Vista Paint | Tudor Ice | #bac7c8 | 1.4 | /colors/vista-paint/tudor-ice-c-1357 |
+
+## Rainwashed — Sherwin-Williams (6211)
+- Hex: #c2cdc5 | LRV: 59.2 | Undertone: Neutral | Family: gray
+- URL: /colors/sherwin-williams/rainwashed-6211
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Frosted Jade | #c2d0c5 | 1.9 | /colors/behr/frosted-jade-ppu11-13 |
+| Benjamin Moore | Silver Marlin | #c1c9c2 | 1.6 | /colors/benjamin-moore/silver-marlin-2139-50 |
+| Colorhouse | Water .02 | #bcc8bc | 2.3 | /colors/colorhouse/water-02-water-02 |
+| Dunn-Edwards | Granite | #c8d1c4 | 2.4 | /colors/dunn-edwards/granite-de6283 |
+| Dutch Boy | Laguna White | #c8cdc9 | 3.5 | /colors/dutch-boy/laguna-white-7411 |
+| Farrow & Ball | Teresa's Green | #c0cdc2 | 1.6 | /colors/farrow-ball/teresas-green-236 |
+| Hirshfield's | Amelia | #beccc2 | 1.6 | /colors/hirshfields/amelia-historic-amelia |
+| Kilz | Loden Frost | #bec5b6 | 3.8 | /colors/kilz/loden-frost-tb-73 |
+| MPC | Frosty Jade Green Met. | #b5c4c1 | 3.6 | /colors/mpc/frosty-jade-green-met-mp23434 |
+| PPG | White Clover | #c4d1c6 | 1.8 | /colors/ppg/white-clover-10-31 |
+| Valspar | Ocean Froth | #c1ccc3 | 0.5 | /colors/valspar/ocean-froth-8003-34c |
+| Vista Paint | Amelia | #bfccc2 | 1.3 | /colors/vista-paint/amelia-c-1385 |
+
+## Van Deusen Blue — Benjamin Moore (HC-156)
+- Hex: #495c6f | LRV: 10.2 | Undertone: Neutral | Family: blue
+- URL: /colors/benjamin-moore/van-deusen-blue-hc-156
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Harbour (marquee) | #485869 | 1.6 | /colors/behr/harbour-marquee-qe-55 |
+| Colorhouse | Wool .06 | #485761 | 4.4 | /colors/colorhouse/wool-06-wool-06 |
+| Dunn-Edwards | Stormy Sea | #4a657a | 3.7 | /colors/dunn-edwards/stormy-sea-de5817 |
+| Farrow & Ball | Stiffkey Blue | #4d5b6a | 1.9 | /colors/farrow-ball/stiffkey-blue-281 |
+| Hirshfield's | Seal Blue | #475663 | 3.3 | /colors/hirshfields/seal-blue-historic-seal-blue |
+| Kilz | Saxophone Solo | #3f556c | 3.0 | /colors/kilz/saxophone-solo-rc290-02 |
+| MPC | Blue Brigantine | #41576b | 2.1 | /colors/mpc/blue-brigantine-mp4518 |
+| PPG | Blue Fjord | #4c6177 | 2.1 | /colors/ppg/blue-fjord-1163-6 |
+| RAL | Brillant Blue | #3e5f8a | 7.1 | /colors/ral/brillant-blue-5007 |
+| Sherwin-Williams | Indigo Batik | #3e5063 | 4.2 | /colors/sherwin-williams/indigo-batik-7602 |
+| Valspar | Hampton Surf | #4d5c6a | 2.1 | /colors/valspar/hampton-surf-4010-5 |
+| Vista Paint | Blazing Sky | #495d6b | 2.8 | /colors/vista-paint/blazing-sky-k-801 |
+
+## Newburyport Blue — Benjamin Moore (HC-155)
+- Hex: #475667 | LRV: 9 | Undertone: Neutral | Family: neutral
+- URL: /colors/benjamin-moore/newburyport-blue-hc-155
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Harbour (marquee) | #485869 | 0.8 | /colors/behr/harbour-marquee-qe-55 |
+| Colorhouse | Wool .06 | #485761 | 3.8 | /colors/colorhouse/wool-06-wool-06 |
+| Dunn-Edwards | Deep Reservoir | #424f5f | 2.4 | /colors/dunn-edwards/deep-reservoir-de5874 |
+| Farrow & Ball | Stiffkey Blue | #4d5b6a | 2.0 | /colors/farrow-ball/stiffkey-blue-281 |
+| Hirshfield's | Seal Blue | #475663 | 2.1 | /colors/hirshfields/seal-blue-historic-seal-blue |
+| Kilz | Saxophone Solo | #3f556c | 2.7 | /colors/kilz/saxophone-solo-rc290-02 |
+| MPC | Blue Brigantine | #41576b | 2.2 | /colors/mpc/blue-brigantine-mp4518 |
+| PPG | Admiralty | #404e61 | 3.0 | /colors/ppg/admiralty-1042-7 |
+| RAL | Slate Grey | #434750 | 6.7 | /colors/ral/slate-grey-7015 |
+| Sherwin-Williams | Indigo Batik | #3e5063 | 2.4 | /colors/sherwin-williams/indigo-batik-7602 |
+| Valspar | Moon Shade | #495765 | 1.4 | /colors/valspar/moon-shade-4006-4c |
+| Vista Paint | Seal Blue | #495764 | 2.0 | /colors/vista-paint/seal-blue-c-1377 |
+
+## Distance — Sherwin-Williams (6243)
+- Hex: #5d6f7f | LRV: 15.2 | Undertone: Neutral | Family: neutral
+- URL: /colors/sherwin-williams/distance-6243
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Hypnotic | #677582 | 3.0 | /colors/behr/hypnotic-mq5-19 |
+| Benjamin Moore | Thousand Oceans | #5f7581 | 3.6 | /colors/benjamin-moore/thousand-oceans-1645 |
+| Dunn-Edwards | Wharf View | #65737e | 2.8 | /colors/dunn-edwards/wharf-view-dec799 |
+| Dutch Boy | Ocean Blue | #4c6a74 | 6.7 | /colors/dutch-boy/ocean-blue-d-6743 |
+| Farrow & Ball | Stiffkey Blue | #4d5b6a | 7.3 | /colors/farrow-ball/stiffkey-blue-281 |
+| Hirshfield's | Blue Depths | #5a7187 | 2.5 | /colors/hirshfields/blue-depths-626 |
+| Kilz | Iron Medallion | #537181 | 4.0 | /colors/kilz/iron-medallion-rd130-02 |
+| MPC | Van Deusen Blue | #536575 | 3.8 | /colors/mpc/van-deusen-blue-mp7440 |
+| PPG | Hatteras Gray | #5c707e | 1.5 | /colors/ppg/hatteras-gray-10-10 |
+| RAL | Pigeon Blue | #606e8c | 7.0 | /colors/ral/pigeon-blue-5014 |
+| Valspar | Smoky Pitch | #606e79 | 2.2 | /colors/valspar/smoky-pitch-4007-4b |
+| Vista Paint | Blue Depths | #596f85 | 2.4 | /colors/vista-paint/blue-depths-c-625 |
+
+## Sea Serpent — Sherwin-Williams (7615)
+- Hex: #3e4b54 | LRV: 6.7 | Undertone: Neutral | Family: neutral
+- URL: /colors/sherwin-williams/sea-serpent-7615
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Orion Gray | #3d4c55 | 0.9 | /colors/behr/orion-gray-n510-6 |
+| Benjamin Moore | Blue Note | #414c55 | 1.0 | /colors/benjamin-moore/blue-note-2129-30 |
+| Colorhouse | Wool .06 | #485761 | 4.1 | /colors/colorhouse/wool-06-wool-06 |
+| Dunn-Edwards | Deepest Sea | #444d56 | 2.1 | /colors/dunn-edwards/deepest-sea-de5825 |
+| Farrow & Ball | Hague Blue | #3d4e57 | 1.8 | /colors/farrow-ball/hague-blue-30 |
+| Hirshfield's | Vermont Slate | #48535a | 3.0 | /colors/hirshfields/vermont-slate-historic-vermont-slate |
+| Kilz | Kettle Black | #47535c | 2.8 | /colors/kilz/kettle-black-re120-02 |
+| MPC | Black Hole Met. | #3b4145 | 4.5 | /colors/mpc/black-hole-met-mp19952 |
+| PPG | Midnight Hour | #3b484f | 1.6 | /colors/ppg/midnight-hour-1038-7 |
+| RAL | Iron Grey | #434b4d | 3.9 | /colors/ral/iron-grey-7011 |
+| Valspar | Pitch Cobalt | #434d56 | 1.6 | /colors/valspar/pitch-cobalt-5010-2 |
+| Vista Paint | Vermont Slate | #495259 | 3.1 | /colors/vista-paint/vermont-slate-c-1464 |
+
+## Rosemary — Sherwin-Williams (6187)
+- Hex: #64695c | LRV: 13.6 | Undertone: Warm (Golden) | Family: gray
+- URL: /colors/sherwin-williams/rosemary-6187
+
+| Closest match in | Color | Hex | Delta E | Link |
+|---|---|---|---|---|
+| Behr | Gray Owl | #646c62 | 2.1 | /colors/behr/gray-owl-bnc-37 |
+| Benjamin Moore | Rainy Afternoon | #656c62 | 1.9 | /colors/benjamin-moore/rainy-afternoon-1575 |
+| Dunn-Edwards | Velvet Clover | #656d63 | 2.3 | /colors/dunn-edwards/velvet-clover-de6293 |
+| Dutch Boy | Ashton Grey | #66665a | 2.8 | /colors/dutch-boy/ashton-grey-vs-9303 |
+| Farrow & Ball | Down Pipe | #626664 | 5.8 | /colors/farrow-ball/down-pipe-26 |
+| Hirshfield's | River God | #6c6c5f | 3.0 | /colors/hirshfields/river-god-450 |
+| Kilz | Yew Hedge | #656952 | 4.1 | /colors/kilz/yew-hedge-lg100-02 |
+| MPC | Warrior Green | #686958 | 2.5 | /colors/mpc/warrior-green-mp12120 |
+| PPG | Double Duty | #686858 | 2.7 | /colors/ppg/double-duty-1030-7 |
+| RAL | Concrete Grey | #686c5e | 1.4 | /colors/ral/concrete-grey-7023 |
+| Valspar | Flora | #5e6357 | 2.3 | /colors/valspar/flora-5004-2c |
+| Vista Paint | Eye of the Storm | #686859 | 2.6 | /colors/vista-paint/eye-of-the-storm-c-422 |

--- a/src/lib/color-editorial.tsx
+++ b/src/lib/color-editorial.tsx
@@ -736,6 +736,205 @@ export const COLOR_EDITORIAL: Record<string, ReactNode> = {
       </p>
     </>
   ),
+  "sherwin-williams/shoji-white-7042": (
+    <>
+      <p>
+        Shoji White is one of Sherwin-Williams&apos; most-used warm off-whites — at LRV 74 it&apos;s the
+        in-between people reach for when a true white feels too cold and a greige feels too gray. It has
+        a soft, warm linen quality that flatters cabinetry, trim, and whole rooms, and it&apos;s a natural
+        partner for the warm-greige walls that replaced the gray era.
+      </p>
+      <p>
+        Because it&apos;s warm, it can read slightly creamy beside a stark white, so keep the whites in a
+        room consistent. It&apos;s most forgiving in soft, natural light. Behr Crisp Linen is a
+        near-identical cross-brand match, with Benjamin Moore Etiquette close behind.
+      </p>
+    </>
+  ),
+  "sherwin-williams/modern-gray-7632": (
+    <>
+      <p>
+        Modern Gray is a light, warm greige at LRV 62 with a subtle taupe-mauve base — the warmest of
+        Sherwin-Williams&apos; popular light neutrals. It&apos;s the choice when Agreeable Gray feels too cool
+        or too gray; it brings genuine warmth to a room without going full beige.
+      </p>
+      <p>
+        That faint violet-taupe undertone is the thing to sample for — in some light it can lean
+        slightly pink, so keep its companions warm. It&apos;s lovely in bedrooms and living rooms with soft
+        light. Behr Mineral is a near-identical match, with Benjamin Moore Rocking Chair close behind.
+      </p>
+    </>
+  ),
+  "sherwin-williams/useful-gray-7050": (
+    <>
+      <p>
+        Useful Gray lives up to its name — a flexible warm greige at LRV 59 that sits comfortably between
+        gray and beige. It&apos;s a close cousin of Benjamin Moore Revere Pewter (a near-identical match),
+        which makes it the SW pick for that same grounded, organic greige look.
+      </p>
+      <p>
+        Its balance is the appeal: enough warmth to feel inviting, enough gray to stay current, and a
+        light-mid LRV that works in most rooms. Like its greige siblings it can show a faint green base
+        in cool light. Behr Coliseum Marble is also a close cross-brand match.
+      </p>
+    </>
+  ),
+  "sherwin-williams/anew-gray-7030": (
+    <>
+      <p>
+        Anew Gray is a mid-tone greige at LRV 47 — deeper and warmer than Agreeable Gray, with enough
+        body to give a room real definition. It&apos;s the choice when you want a greige that reads as an
+        actual color rather than a pale backdrop, especially in well-lit rooms.
+      </p>
+      <p>
+        At this depth it can go noticeably darker in low light, so check it in your own space before a
+        whole-house commit. It pairs well with white trim and warm wood. Behr Grey Mist and Benjamin
+        Moore Silver Fox are its closest cross-brand matches.
+      </p>
+    </>
+  ),
+  "sherwin-williams/amazing-gray-7044": (
+    <>
+      <p>
+        Amazing Gray is a mid-tone greige at LRV 47 in the same depth range as Anew Gray, with a warm,
+        slightly earthy base. It&apos;s a strong choice for open-plan spaces that want a grounded neutral
+        with presence — deep enough to anchor a room, warm enough to stay welcoming.
+      </p>
+      <p>
+        As with any mid-tone greige, it darkens in low light and shows its warmth in bright light, so
+        sample in place. It pairs with crisp white trim and natural materials. Behr Grey Mist and
+        Benjamin Moore Silver Fox are its closest matches.
+      </p>
+    </>
+  ),
+  "benjamin-moore/natural-linen-966": (
+    <>
+      <p>
+        Natural Linen is a warm, soft greige-tan at LRV 60 — the kind of light earth-tone that reads
+        cozy and organic without going yellow. It&apos;s a versatile whole-house neutral for people who
+        lean warm, sitting a touch more beige than the popular gray-greiges.
+      </p>
+      <p>
+        Its warmth makes it forgiving in north-facing rooms where cooler neutrals can feel flat, but it
+        can look creamy beside a stark white. It pairs naturally with wood and warm whites. Its
+        near-identical Sherwin-Williams match is Wool Skein.
+      </p>
+    </>
+  ),
+  "sherwin-williams/white-heron-7627": (
+    <>
+      <p>
+        White Heron is a soft, clean white at LRV 76 with just a whisper of warmth — crisp enough to feel
+        fresh, soft enough to avoid the chill of a true cool white. It&apos;s a flexible choice for trim,
+        walls, and cabinets, especially in rooms that get good light.
+      </p>
+      <p>
+        Its gentle warmth keeps it livable, but like any soft white it can look faintly creamy beside a
+        bright white, so keep the whites consistent. Behr Cinnamon Cake is a near-identical match, with
+        Benjamin Moore Etiquette close behind.
+      </p>
+    </>
+  ),
+  "sherwin-williams/sleepy-blue-6225": (
+    <>
+      <p>
+        Sleepy Blue is the soft, calming powder blue-gray its name promises — at LRV 58 it&apos;s light and
+        restful, the kind of gentle blue that works beautifully in bedrooms, nurseries, and bathrooms
+        without feeling juvenile. It&apos;s a muted, grayed blue rather than a bright one.
+      </p>
+      <p>
+        Because it&apos;s soft and grayed, it reads as a serene near-neutral, though it can lean cooler in
+        north light. It pairs with crisp whites and natural wood. Behr High Speed Access and Benjamin
+        Moore Smoke are its closest cross-brand matches.
+      </p>
+    </>
+  ),
+  "sherwin-williams/rainwashed-6211": (
+    <>
+      <p>
+        Rainwashed is Sherwin-Williams&apos; soft spa blue-green — a cousin of Sea Salt, a touch bluer and
+        at a similar LRV 59. It has the same chameleon quality, shifting between pale aqua, soft green,
+        and gray depending on the light, which is why it&apos;s a perennial favorite for bathrooms and
+        coastal-feeling rooms.
+      </p>
+      <p>
+        That shape-shifting means you can&apos;t judge it from the chip — sample it where it&apos;s going. It
+        pairs with crisp whites and warm wood and fights cool grays. Benjamin Moore Silver Marlin and
+        Behr Frosted Jade are its closest cross-brand matches.
+      </p>
+    </>
+  ),
+  "benjamin-moore/van-deusen-blue-hc-156": (
+    <>
+      <p>
+        Van Deusen Blue is a deep, historic navy with a slate-gray softness — at LRV 10 it&apos;s dark and
+        dramatic, but its grayed base keeps it from reading as a bright or primary blue. It&apos;s a
+        sophisticated choice for cabinetry, libraries, and statement walls in traditional homes.
+      </p>
+      <p>
+        Like any deep blue it needs light to keep from collapsing toward black, and it looks richest
+        with warm whites, brass, and wood. It sits in the same deep-blue family as Hale Navy but reads a
+        touch grayer. Behr Harbour is its closest cross-brand match.
+      </p>
+    </>
+  ),
+  "benjamin-moore/newburyport-blue-hc-155": (
+    <>
+      <p>
+        Newburyport Blue is the navy that sits right beside Hale Navy in Benjamin Moore&apos;s Historical
+        Collection — at LRV 9 it&apos;s a rich, classic navy with a slightly cooler, bluer character than
+        Hale Navy&apos;s gray-green softness. It&apos;s the pick when you want a navy that reads a little more
+        true-blue.
+      </p>
+      <p>
+        As a deep color it&apos;s best with good light or used deliberately for drama on doors, islands, and
+        built-ins. It pairs with crisp and warm whites alike. Behr Harbour is a near-identical
+        cross-brand match.
+      </p>
+    </>
+  ),
+  "sherwin-williams/distance-6243": (
+    <>
+      <p>
+        Distance is a deep, moody blue-gray slate at LRV 15 — darker and grayer than a true navy, which
+        gives it a sophisticated, almost stormy quality. It&apos;s a strong choice for an accent wall,
+        cabinetry, or a study you want to feel enveloping and a little dramatic.
+      </p>
+      <p>
+        At this depth it shifts noticeably with light — bluer in daylight, grayer and darker in shadow —
+        so sample it in place. It pairs with warm metals and crisp whites. Behr Hypnotic is a very close
+        cross-brand match, with Benjamin Moore Thousand Oceans very similar.
+      </p>
+    </>
+  ),
+  "sherwin-williams/sea-serpent-7615": (
+    <>
+      <p>
+        Sea Serpent is a deep, complex teal that lives between blue and green — at LRV 7 it&apos;s rich and
+        saturated, the kind of jewel tone that turns a powder room, a built-in, or an accent wall into a
+        focal point. It reads more blue in some light, more green in others.
+      </p>
+      <p>
+        As a deep, saturated color it amplifies lighting and needs some daylight to show its depth
+        rather than going near-black. It looks striking with brass, warm wood, and creamy whites. Behr
+        Orion Gray and Benjamin Moore Blue Note are its closest cross-brand matches.
+      </p>
+    </>
+  ),
+  "sherwin-williams/rosemary-6187": (
+    <>
+      <p>
+        Rosemary is a deep, earthy green at LRV 14 — a grayed, herbal green with real depth that brings
+        a grounded, natural drama to a room. It&apos;s the choice for a moody green on cabinetry, a library,
+        or an accent wall, in the family of the deep-sage trend but darker and more saturated.
+      </p>
+      <p>
+        At this depth it needs light to read as green rather than near-black, and it pairs beautifully
+        with warm whites, brass, and natural wood. Benjamin Moore Rainy Afternoon and Behr Gray Owl are
+        its closest cross-brand matches.
+      </p>
+    </>
+  ),
 };
 
 export function getColorEditorial(brandSlug: string, colorSlug: string): ReactNode | null {


### PR DESCRIPTION
## Summary
Fifth batch — 14 more curated reviews: popular warm whites/greiges + blues + deep green/teal. All DB-verified, plain-language Delta E.

- **Whites/greiges (7):** SW Shoji White, Modern Gray, Useful Gray, Anew Gray, Amazing Gray, White Heron; BM Natural Linen
- **Blues (5):** SW Sleepy Blue, Rainwashed; BM Van Deusen Blue, Newburyport Blue; SW Distance
- **Deep green/teal (2):** SW Sea Serpent, Rosemary

`COLOR_EDITORIAL` now covers the **62 most-searched colors across 5 brands**. Long tail keeps generated content (HCU-safe).

## Verification
- [x] `tsc` + eslint clean; all 14 slugs confirmed real pages; matches DB-verified.
- [ ] Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)