### PR TITLE
feat(monetization): affiliate-ready sample + retailer links on color pages

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,15 @@
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# --- Affiliate / monetization (optional) ---
+# Color pages add "Order a sample" + Amazon links. Set these to monetize them;
+# leave unset and the links work as plain (unmonetized) links. Public values.
+# Samplize via ShareASale: your deep-link prefix ending in "&urllink="
+NEXT_PUBLIC_SAMPLIZE_AFFILIATE_PREFIX=
+# Amazon Associates store tag, e.g. paintcolorhq-20
+NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG=
+# Home Depot affiliate (Impact) deep-link prefix, ending before the target URL
+NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX=
+# Lowe's affiliate (Impact/CJ) deep-link prefix
+NEXT_PUBLIC_LOWES_AFFILIATE_PREFIX=

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -16,6 +16,7 @@ import { generateColorDescription, generateEditorialVerdict, generateMetaDescrip
 import { getColorEditorial } from "@/lib/color-editorial";
 import { getUndertoneDotClass } from "@/lib/undertone-utils";
 import { getRetailerLinks } from "@/lib/retailer-links";
+import { getSampleLinks, affiliatizeRetailer, AFFILIATE_ENABLED } from "@/lib/affiliate";
 import { TrackPage } from "@/components/track-page";
 import { TrackedLink } from "@/components/tracked-link";
 import { PairingSelector } from "@/components/pairing-selector";
@@ -222,6 +223,7 @@ export default async function ColorPage({ params }: PageProps) {
   // Curated, hand-written review for high-demand colors (null for the long tail).
   const curatedEditorial = getColorEditorial(brandSlug, colorSlug);
   const retailerLinks = getRetailerLinks(color.brand.slug, color.brand.name, color.name, color.color_number ?? undefined, color.color_family ?? undefined);
+  const sampleLinks = getSampleLinks({ brandName: color.brand.name, colorName: color.name, colorNumber: color.color_number });
   const harmonies = await resolveHarmonies(color.hex);
   const light = isLightColor(color.hex);
   const textClass = light ? "text-on-surface" : "text-on-primary";
@@ -421,12 +423,37 @@ export default async function ColorPage({ params }: PageProps) {
               <TrackedLink href={`/compare?color1=${color.id}`} className="bg-surface-container-highest text-primary px-6 py-3 rounded-xl font-headline font-bold text-sm" eventName="cta_click" eventParams={{ cta_label: "compare", color_name: color.name, color_brand: color.brand.slug }}>
                 Compare
               </TrackedLink>
-              {retailerLinks.map((link) => (
-                <a key={link.retailerName} href={link.url} target="_blank" rel="noopener noreferrer" className="bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/15 hover:shadow-md transition-all">
-                  Buy at {link.retailerName}
+              {/* Sample-purchase CTAs (affiliate when configured) — highest-intent
+                  next step for a color page. rel="sponsored nofollow" per FTC/SEO. */}
+              {sampleLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.url}
+                  target="_blank"
+                  rel="sponsored nofollow noopener noreferrer"
+                  className={
+                    link.primary
+                      ? "bg-gradient-to-br from-primary to-primary-container text-on-primary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-primary/20 hover:shadow-xl transition-all"
+                      : "bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/15 hover:shadow-md transition-all"
+                  }
+                >
+                  {link.primary ? `${link.label} of ${color.name}` : link.label}
                 </a>
               ))}
+              {retailerLinks.map((link) => {
+                const a = affiliatizeRetailer(link.url);
+                return (
+                  <a key={link.retailerName} href={a.url} target="_blank" rel={`${a.affiliate ? "sponsored " : ""}nofollow noopener noreferrer`} className="bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/15 hover:shadow-md transition-all">
+                    Buy at {link.retailerName}
+                  </a>
+                );
+              })}
             </div>
+            {AFFILIATE_ENABLED && (
+              <p className="mt-4 text-xs text-on-surface-variant">
+                Some sample and supply links are affiliate links — if you buy through them, Paint Color HQ may earn a small commission at no extra cost to you. It helps keep the site free.
+              </p>
+            )}
           </div>
 
           <div className="lg:col-span-7">

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,0 +1,94 @@
+// Affiliate / sample-purchase links for color pages.
+//
+// Affiliate IDs are read from env vars — nothing is hardcoded, so no secrets are
+// committed. When an ID isn't set, the link falls back to the plain (unmonetized
+// but still useful) destination, so a link is never broken or missing. The day
+// you add the IDs in Vercel, the same links start earning — no code change.
+//
+// Env (set in Vercel → Project → Settings → Environment Variables; NOT committed):
+//   NEXT_PUBLIC_SAMPLIZE_AFFILIATE_PREFIX
+//     Your ShareASale (or other network) deep-link prefix, ending right before
+//     the target URL — e.g.
+//     "https://shareasale.com/r.cfm?b=<bannerId>&u=<yourAffId>&m=<samplizeMerchantId>&urllink="
+//     The encoded Samplize URL is appended to it.
+//   NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG
+//     Your Amazon Associates store tag, e.g. "paintcolorhq-20".
+//   NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX
+//     Home Depot affiliate (Impact) deep-link prefix ending right before the
+//     target URL — the existing homedepot.com link is appended, URL-encoded.
+//   NEXT_PUBLIC_LOWES_AFFILIATE_PREFIX
+//     Lowe's affiliate (Impact/CJ) deep-link prefix, same format.
+// Note: Sherwin-Williams and Benjamin Moore have no consumer affiliate program
+// (they sell through their own stores / dealers) — those brand links stay plain;
+// Samplize captures that purchase intent instead.
+
+export interface SampleLink {
+  label: string;
+  url: string;
+  /** true once an affiliate ID is configured for this destination */
+  affiliate: boolean;
+  /** render as the prominent primary CTA */
+  primary?: boolean;
+}
+
+interface SampleInfo {
+  brandName: string;
+  colorName: string;
+  colorNumber?: string | null;
+}
+
+const SAMPLIZE_PREFIX = process.env.NEXT_PUBLIC_SAMPLIZE_AFFILIATE_PREFIX;
+const AMAZON_TAG = process.env.NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG;
+const HOMEDEPOT_PREFIX = process.env.NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX;
+const LOWES_PREFIX = process.env.NEXT_PUBLIC_LOWES_AFFILIATE_PREFIX;
+
+/** True when at least one affiliate program is configured — gates the FTC disclosure. */
+export const AFFILIATE_ENABLED = Boolean(
+  SAMPLIZE_PREFIX || AMAZON_TAG || HOMEDEPOT_PREFIX || LOWES_PREFIX
+);
+
+/**
+ * Wrap an existing retailer URL in an affiliate deep-link when a program is
+ * configured for that retailer. Returns the plain URL + affiliate:false otherwise,
+ * so a missing ID never breaks a link. Used on the "Buy at …" retailer links.
+ */
+export function affiliatizeRetailer(url: string): { url: string; affiliate: boolean } {
+  if (HOMEDEPOT_PREFIX && url.includes("homedepot.com")) {
+    return { url: `${HOMEDEPOT_PREFIX}${encodeURIComponent(url)}`, affiliate: true };
+  }
+  if (LOWES_PREFIX && url.includes("lowes.com")) {
+    return { url: `${LOWES_PREFIX}${encodeURIComponent(url)}`, affiliate: true };
+  }
+  if (AMAZON_TAG && url.includes("amazon.com")) {
+    const sep = url.includes("?") ? "&" : "?";
+    return { url: `${url}${sep}tag=${AMAZON_TAG}`, affiliate: true };
+  }
+  return { url, affiliate: false };
+}
+
+export function getSampleLinks(info: SampleInfo): SampleLink[] {
+  const query = [info.brandName, info.colorName].filter(Boolean).join(" ");
+  const links: SampleLink[] = [];
+
+  // Samplize — peel-and-stick paint samples. The highest-intent action on a
+  // color page: someone researching a color wants to see it on their own wall.
+  const samplizeTarget = `https://www.samplize.com/search?q=${encodeURIComponent(query)}`;
+  links.push({
+    label: "Order a peel-and-stick sample",
+    url: SAMPLIZE_PREFIX ? `${SAMPLIZE_PREFIX}${encodeURIComponent(samplizeTarget)}` : samplizeTarget,
+    affiliate: Boolean(SAMPLIZE_PREFIX),
+    primary: true,
+  });
+
+  // Amazon — sample pots, swatch cards, and painting supplies.
+  const amazonUrl = `https://www.amazon.com/s?k=${encodeURIComponent(`${query} paint sample`)}${
+    AMAZON_TAG ? `&tag=${AMAZON_TAG}` : ""
+  }`;
+  links.push({
+    label: "Samples & supplies on Amazon",
+    url: amazonUrl,
+    affiliate: Boolean(AMAZON_TAG),
+  });
+
+  return links;
+}


### PR DESCRIPTION
## Summary
Turns the site's existing purchase-intent traffic into revenue — **env-driven so no secrets are committed**, with graceful fallback (plain links) until you add affiliate IDs in Vercel. Starts earning the moment the env vars are set; **no code change and no regression** in the meantime.

## What it does
- **`src/lib/affiliate.ts`**
  - `getSampleLinks()` — adds **Samplize** (peel-and-stick samples, the highest-intent action on a color page) + **Amazon** (samples/supplies) to every color page.
  - `affiliatizeRetailer()` — wraps the existing **Home Depot / Lowe's / Amazon** "Buy at…" links in affiliate deep-links when configured.
- **Color page** — prominent "Order a peel-and-stick sample of [color]" CTA + Amazon link; existing retailer links affiliate-wrapped where a program exists.
- **SEO + FTC** — affiliate links `rel="sponsored nofollow"`; the plain external retailer links **fixed to `rel="nofollow"`** (they were missing it — a real SEO issue); FTC affiliate disclosure shown whenever a program is configured.

## Affiliate program reality (answer to "do HD/Lowe's/SW have programs?")
- **Home Depot — yes** (Impact). Covers Behr/PPG/Glidden/Kilz.
- **Lowe's — yes** (Impact/CJ). Covers Valspar.
- **Sherwin-Williams / Benjamin Moore — no** consumer program (own stores / dealers). Their brand links stay plain; **Samplize** captures that intent (sells SW/BM samples).

## What you need to do to switch it on
Sign up + set these in Vercel env (all optional, public values):
- `NEXT_PUBLIC_SAMPLIZE_AFFILIATE_PREFIX` (Samplize via ShareASale — covers SW/BM/everything)
- `NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG` (Amazon Associates)
- `NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX` (Impact)
- `NEXT_PUBLIC_LOWES_AFFILIATE_PREFIX` (Impact/CJ)

## Verification
- [x] `tsc` clean; graceful fallback when env unset (verified — links render as plain URLs).
- [ ] Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)