### PR TITLE
feat(facebook): cross-post the pin queue to the Paint Color HQ Page

### DIFF
--- a/scripts/facebook-publish.ts
+++ b/scripts/facebook-publish.ts
@@ -1,0 +1,163 @@
+/**
+ * Facebook Page publisher — cross-posts the same approved queue to the
+ * Paint Color HQ Page. Sibling of instagram-publish.ts; shares all caption /
+ * eligibility logic via social-content.ts.
+ *
+ * Unlike Instagram, Facebook posts CAN carry a clickable link, so the caption
+ * includes the (FB-attributed) destination URL — this lane can actually drive
+ * traffic, not just impressions.
+ *
+ * Publish: mint a Page access token from the Business system-user token, then
+ *   POST /{PAGE_ID}/photos  (url = the 4:5 pin image, message = caption)
+ * (A system-user token can't post to a Page directly — Graph returns #200 — but
+ *  the Page token derived from it can.)
+ *
+ * Separate log (scripts/facebook/fb-published.json) so a pin can post to
+ * Pinterest, Instagram, AND Facebook independently without double-posting.
+ *
+ * Env (.env.local, untracked):
+ *   META_PAGE_ACCESS_TOKEN   system-user token with pages_manage_posts
+ *   META_PAGE_ID             the Facebook Page id
+ *   META_GRAPH_VERSION       optional, defaults to v23.0
+ *
+ * Usage:
+ *   npx tsx scripts/facebook-publish.ts --dry-run --drip=1
+ *   npx tsx scripts/facebook-publish.ts --drip=1
+ *   npx tsx scripts/facebook-publish.ts --only=<queue-key>
+ */
+import * as path from "path";
+import * as fs from "fs";
+import { execFile } from "child_process";
+import { fileURLToPath } from "url";
+import * as dotenv from "dotenv";
+import { QUEUE, selectForDrip, unpublished, type PinSpec, type PublishedLog } from "./pinterest/queue.ts";
+import { eligible, imageUrl4x5, buildCaption } from "./social-content.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ENV_PATH = path.resolve(__dirname, "../.env.local");
+const LOG_PATH = path.resolve(__dirname, "facebook/fb-published.json");
+dotenv.config({ path: ENV_PATH });
+
+const TOKEN = process.env.META_PAGE_ACCESS_TOKEN;
+const PAGE_ID = process.env.META_PAGE_ID;
+const VERSION = process.env.META_GRAPH_VERSION || "v23.0";
+const GRAPH = `https://graph.facebook.com/${VERSION}`;
+
+/** macOS local notification — best-effort, never throws. */
+function notify(message: string) {
+  execFile(
+    "osascript",
+    ["-e", `display notification "${message.replace(/"/g, "'")}" with title "PaintColorHQ"`],
+    () => {},
+  );
+}
+
+// ---- CLI args ----
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const dripArg = args.find((a) => a.startsWith("--drip="));
+const DRIP = dripArg ? Math.max(1, parseInt(dripArg.replace("--drip=", ""), 10) || 1) : null;
+const onlyArg = args.find((a) => a.startsWith("--only="));
+const onlyKeys = onlyArg ? new Set(onlyArg.replace("--only=", "").split(",")) : null;
+
+// ---- log helpers ----
+type FbPublishedLog = Record<string, { postId: string; publishedAt: string }>;
+function loadLog(): FbPublishedLog {
+  try {
+    return JSON.parse(fs.readFileSync(LOG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function saveLog(log: FbPublishedLog) {
+  fs.writeFileSync(LOG_PATH, JSON.stringify(log, null, 2) + "\n");
+}
+
+/** A system-user token can't post to a Page; derive the Page token once. */
+let pageToken: string | null = null;
+async function getPageToken(): Promise<string> {
+  if (pageToken) return pageToken;
+  const res = await fetch(`${GRAPH}/${PAGE_ID}?fields=access_token&access_token=${TOKEN}`);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.access_token) {
+    throw new Error(`Could not get Page token: ${JSON.stringify(data?.error ?? data)}`);
+  }
+  pageToken = data.access_token as string;
+  return pageToken;
+}
+
+async function publishOne(pin: PinSpec, log: FbPublishedLog) {
+  const tag = `${pin.key} ${pin.name}`;
+  if (log[pin.key]) {
+    console.log(`⏭️  ${tag} — already posted (post ${log[pin.key].postId})`);
+    return;
+  }
+  const imageUrl = imageUrl4x5(pin);
+  const message = buildCaption(pin, "facebook");
+
+  if (DRY_RUN) {
+    console.log(`🧪 [${pin.type}] ${tag}  [${message.length} chars]`);
+    console.log(`     image: ${imageUrl}`);
+    console.log(message.split("\n").map((l) => `     | ${l}`).join("\n"));
+    console.log("");
+    return;
+  }
+
+  const token = await getPageToken();
+  const body = new URLSearchParams({ url: imageUrl, message, access_token: token });
+  const res = await fetch(`${GRAPH}/${PAGE_ID}/photos`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${res.status}: ${JSON.stringify(data?.error ?? data)}`);
+
+  log[pin.key] = { postId: data.post_id ?? data.id, publishedAt: new Date().toISOString() };
+  saveLog(log);
+  console.log(`✅ ${tag} → post ${log[pin.key].postId}`);
+}
+
+async function main() {
+  if (!TOKEN || !PAGE_ID) {
+    throw new Error("Missing META_PAGE_ACCESS_TOKEN or META_PAGE_ID in .env.local");
+  }
+  const log = loadLog();
+  const pool = QUEUE.filter(eligible);
+
+  let targets: PinSpec[];
+  if (DRIP) {
+    targets = selectForDrip(pool, log as unknown as PublishedLog, DRIP);
+    if (targets.length === 0) {
+      console.log("Drip: no unpublished FB-eligible pins left.");
+      if (!DRY_RUN) notify("Facebook queue empty — stock more pins with Claude.");
+      return;
+    }
+  } else if (onlyKeys) {
+    targets = pool.filter((p) => onlyKeys.has(p.key));
+  } else {
+    targets = unpublished(pool, log as unknown as PublishedLog);
+  }
+
+  console.log(
+    `${DRY_RUN ? "DRY RUN — " : ""}Posting ${targets.length} to Facebook` +
+      `${DRIP ? " (drip, variety rotation)" : onlyKeys ? ` (--only)` : " (all unpublished)"}\n`,
+  );
+
+  for (const pin of targets) {
+    try {
+      await publishOne(pin, log);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`❌ ${pin.key} ${pin.name}: ${msg}`);
+      if (!DRY_RUN && /OAuth|token|\b190\b|\b200\b|permission/i.test(msg)) {
+        notify("Facebook auth failed — check the Meta system-user token / pages_manage_posts.");
+      }
+    }
+    if (!DRY_RUN) await new Promise((r) => setTimeout(r, 3000));
+  }
+  console.log("\nDone.");
+}
+
+main();

--- a/scripts/facebook/com.paintcolorhq.facebook-drip.plist.template
+++ b/scripts/facebook/com.paintcolorhq.facebook-drip.plist.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>__LABEL__</string>
+  <!-- Invoke /bin/bash DIRECTLY (not the script via its shebang): macOS TCC
+       attributes file access to the launchd program, so the FDA-granted
+       /bin/bash must be the program — otherwise runs fail with "Operation not
+       permitted" reading the repo (~/Documents). -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__DRIPSH__</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>__NODE_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <!-- 18:00 UTC (2pm EDT) — offset from Pinterest (14:00) and Instagram (16:00)
+       so the three drips don't run at once. -->
+  <key>StartCalendarInterval</key>
+  <dict><key>Hour</key><integer>18</integer><key>Minute</key><integer>0</integer></dict>
+  <key>StandardErrorPath</key><string>__REPO__/scripts/facebook/drip.log</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/facebook/drip.sh
+++ b/scripts/facebook/drip.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# launchd entry point for the Facebook Page drip. Resolves the repo root from its
+# own location, then cross-posts one eligible pin via the variety rotation
+# (--drip=1). Logs to drip.log.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+echo "=== fb drip run $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "$REPO/scripts/facebook/drip.log"
+npx tsx scripts/facebook-publish.ts --drip=1 >> "$REPO/scripts/facebook/drip.log" 2>&1

--- a/scripts/facebook/fb-published.json
+++ b/scripts/facebook/fb-published.json
@@ -1,0 +1,10 @@
+{
+  "swatch-sherwin-williams-agreeable-gray-7029": {
+    "postId": "996679250203039_122116668626980879",
+    "publishedAt": "2026-06-05T06:09:41.000Z"
+  },
+  "guide-best-dunn-edwards-paint-colors": {
+    "postId": "996679250203039_122116669310980879",
+    "publishedAt": "2026-06-05T06:11:10.191Z"
+  }
+}

--- a/scripts/facebook/install-drip-schedule.sh
+++ b/scripts/facebook/install-drip-schedule.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Render the launchd plist with this machine's paths and (un)load it.
+# Run this from the PERMANENT repo checkout (not a temporary worktree), since
+# the launchd agent will reference whatever path this resolves to.
+#
+# Usage: ./install-drip-schedule.sh           # install
+#        ./install-drip-schedule.sh uninstall # remove
+set -euo pipefail
+LABEL="com.paintcolorhq.facebook-drip"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if [[ "${1:-}" == "uninstall" ]]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "Uninstalled $LABEL."
+  exit 0
+fi
+
+DRIPSH="$REPO/scripts/facebook/drip.sh"
+NODE_DIR="$(dirname "$(command -v node)")"
+chmod +x "$DRIPSH"
+mkdir -p "$HOME/Library/LaunchAgents"
+sed -e "s|__LABEL__|$LABEL|g" \
+    -e "s|__DRIPSH__|$DRIPSH|g" \
+    -e "s|__NODE_DIR__|$NODE_DIR|g" \
+    -e "s|__REPO__|$REPO|g" \
+    "$REPO/scripts/facebook/com.paintcolorhq.facebook-drip.plist.template" > "$PLIST"
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+echo "Installed $LABEL — cross-posts one eligible pin daily at 18:00 UTC (2pm EDT)."
+echo "Repo: $REPO"
+echo "Logs: $REPO/scripts/facebook/drip.log"
+echo "Uninstall: ./scripts/facebook/install-drip-schedule.sh uninstall"
+echo ""
+echo "Full Disk Access for /bin/bash + node is shared with the Pinterest/Instagram"
+echo "drips — if those run, this is already covered."

--- a/scripts/instagram-publish.ts
+++ b/scripts/instagram-publish.ts
@@ -6,7 +6,8 @@
  * Instagram's Content Publishing API needs a public image_url — it can't take
  * a base64 upload — so the curated local-file pins (palette/comparison) are not
  * IG-eligible yet. Each eligible image is requested at ?ar=4:5 (1080×1350)
- * because IG rejects the 2:3 Pinterest ratio.
+ * because IG rejects the 2:3 Pinterest ratio. Caption logic is shared with the
+ * Facebook publisher in social-content.ts.
  *
  * Publish is a 2-step container flow against the Graph API:
  *   1. POST /{IG_ID}/media        (image_url + caption)  -> creation id
@@ -25,7 +26,7 @@
  * Usage:
  *   npx tsx scripts/instagram-publish.ts --dry-run --drip=1   # show selection
  *   npx tsx scripts/instagram-publish.ts --drip=1             # post next (variety rotation)
- *   npx tsx scripts/instagram-publish.ts --only=swatch-sherwin-williams-agreeable-gray-7029
+ *   npx tsx scripts/instagram-publish.ts --only=<queue-key>
  */
 import * as path from "path";
 import * as fs from "fs";
@@ -33,6 +34,7 @@ import { execFile } from "child_process";
 import { fileURLToPath } from "url";
 import * as dotenv from "dotenv";
 import { QUEUE, selectForDrip, unpublished, type PinSpec, type PublishedLog } from "./pinterest/queue.ts";
+import { eligible, imageUrl4x5, buildCaption } from "./social-content.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -61,80 +63,6 @@ const dripArg = args.find((a) => a.startsWith("--drip="));
 const DRIP = dripArg ? Math.max(1, parseInt(dripArg.replace("--drip=", ""), 10) || 1) : null;
 const onlyArg = args.find((a) => a.startsWith("--only="));
 const onlyKeys = onlyArg ? new Set(onlyArg.replace("--only=", "").split(",")) : null;
-
-// ---- IG-eligible lanes ----
-/** Only pins whose image is a public /api/pin* URL can be cross-posted to IG. */
-function igEligible(p: PinSpec): boolean {
-  return Boolean(p.imageUrl && p.imageUrl.includes("/api/pin"));
-}
-
-/** Force the Instagram 4:5 render of a /api/pin* image (it already has a query). */
-function igImageUrl(p: PinSpec): string {
-  return `${p.imageUrl}&ar=4:5`;
-}
-
-/**
- * LRV → plain-language character, in the site's no-raw-numbers voice. Gives each
- * swatch caption a warm, human line instead of a data dump.
- */
-function characterNoun(lrv: number | null, family: string): string {
-  // High-LRV warm families (yellow/orange/red/brown) are off-whites & creams in
-  // practice — Alabaster is family "yellow" but reads as a warm white. Don't
-  // call those by their underlying family; it undercuts the data we show.
-  const warm = ["yellow", "orange", "red", "brown", "gold", "beige", "tan"];
-  if (lrv != null && lrv >= 73 && warm.includes(family)) return "warm white";
-  if (lrv != null && lrv >= 80 && ["gray", "neutral", "white", "", "color"].includes(family)) {
-    return "soft white";
-  }
-  return family && !["color", "guide", "swatch"].includes(family) ? family : "shade";
-}
-
-function colorCharacter(lrv: number | null, family: string): string {
-  const f = characterNoun(lrv, family);
-  if (lrv == null) return `a beautiful ${f}`;
-  if (lrv >= 70) return `a light, airy ${f}`;
-  if (lrv >= 55) return `a soft, versatile ${f}`;
-  if (lrv >= 40) return `a warm mid-tone ${f}`;
-  if (lrv >= 25) return `a rich, grounded ${f}`;
-  return `a deep, dramatic ${f}`;
-}
-
-function hashtagsFor(p: PinSpec): string {
-  const generic = ["paintcolors", "paint", "interiordesign", "homedecor", "homeimprovement", "colorinspiration"];
-  const themeTag = (p.theme || "").replace(/[^a-z0-9]/gi, "").toLowerCase();
-  const skip = new Set(["", "color", "swatch", "guide", "paint"]);
-  const tags = [...generic];
-  if (!skip.has(themeTag)) tags.push(`${themeTag}paint`);
-  return tags.map((t) => `#${t}`).join(" ");
-}
-
-/**
- * Build the IG caption around the site's real arc — discover the color you love,
- * see it in your room, find where to buy it. Never "match across brands."
- */
-function buildCaption(p: PinSpec): string {
-  let lead: string;
-  let body: string;
-  let cta: string;
-  if (p.type === "swatch") {
-    const params = new URL(p.imageUrl!).searchParams;
-    const name = params.get("name") ?? p.name;
-    const code = params.get("code") ?? "";
-    const lrvRaw = params.get("lrv");
-    const lrv = lrvRaw ? parseInt(lrvRaw, 10) : null;
-    const family = params.get("family") ?? p.theme;
-    lead = [params.get("brand") ?? "", name, code].filter(Boolean).join(" ");
-    const character = colorCharacter(lrv, family);
-    body = `${character.charAt(0).toUpperCase()}${character.slice(1)}${lrv != null ? ` (LRV ${lrv})` : ""}.`;
-    cta = "✨ See it in a real room and find the best place to buy it 👇\npaintcolorhq.com (link in bio)";
-  } else {
-    // guide (or other): the post title + excerpt already read as prose.
-    lead = p.name;
-    body = p.description;
-    cta = "✨ Discover the colors, picture them in your space, and find where to buy 👇\npaintcolorhq.com (link in bio)";
-  }
-  return [lead, "", body, "", cta, "", hashtagsFor(p)].join("\n");
-}
 
 // ---- log helpers ----
 type IgPublishedLog = Record<string, { mediaId: string; publishedAt: string }>;
@@ -183,8 +111,8 @@ async function publishOne(pin: PinSpec, log: IgPublishedLog) {
     console.log(`⏭️  ${tag} — already posted (media ${log[pin.key].mediaId})`);
     return;
   }
-  const imageUrl = igImageUrl(pin);
-  const caption = buildCaption(pin);
+  const imageUrl = imageUrl4x5(pin);
+  const caption = buildCaption(pin, "instagram");
 
   if (DRY_RUN) {
     console.log(`🧪 [${pin.type}] ${tag}  [${caption.length} chars]`);
@@ -194,7 +122,6 @@ async function publishOne(pin: PinSpec, log: IgPublishedLog) {
     return;
   }
 
-  // 1. create container, 2. wait, 3. publish
   const { id: creationId } = await graph(`${IG_ID}/media`, { image_url: imageUrl, caption }, "POST");
   await waitForContainer(creationId);
   const { id: mediaId } = await graph(`${IG_ID}/media_publish`, { creation_id: creationId }, "POST");
@@ -209,21 +136,20 @@ async function main() {
     throw new Error("Missing META_PAGE_ACCESS_TOKEN or IG_BUSINESS_ACCOUNT_ID in .env.local");
   }
   const log = loadLog();
-  const eligible = QUEUE.filter(igEligible);
+  const pool = QUEUE.filter(eligible);
 
   let targets: PinSpec[];
   if (DRIP) {
-    targets = selectForDrip(eligible, log as unknown as PublishedLog, DRIP);
+    targets = selectForDrip(pool, log as unknown as PublishedLog, DRIP);
     if (targets.length === 0) {
       console.log("Drip: no unpublished IG-eligible pins left.");
       if (!DRY_RUN) notify("Instagram queue empty — stock more pins with Claude.");
       return;
     }
   } else if (onlyKeys) {
-    targets = eligible.filter((p) => onlyKeys.has(p.key));
+    targets = pool.filter((p) => onlyKeys.has(p.key));
   } else {
-    // No flag: post every unpublished eligible pin (manual backfill).
-    targets = unpublished(eligible, log as unknown as PublishedLog);
+    targets = unpublished(pool, log as unknown as PublishedLog);
   }
 
   console.log(
@@ -237,7 +163,6 @@ async function main() {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       console.error(`❌ ${pin.key} ${pin.name}: ${msg}`);
-      // The drip runs unattended — surface auth failures so they don't die silently.
       if (!DRY_RUN && /OAuth|token|\b190\b|permission/i.test(msg)) {
         notify("Instagram auth failed — regenerate the Meta system-user token.");
       }

--- a/scripts/social-content.ts
+++ b/scripts/social-content.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared caption + eligibility logic for the social cross-posters (Instagram,
+ * Facebook). Both networks pull from the same Pinterest QUEUE; this module keeps
+ * their copy identical and on-message: discover the color you love → see it in a
+ * room → find where to buy it. Never "match across brands."
+ */
+import type { PinSpec } from "./pinterest/queue.ts";
+
+export type Network = "instagram" | "facebook";
+
+/** Only pins whose image is a public /api/pin* URL can be cross-posted. */
+export function eligible(p: PinSpec): boolean {
+  return Boolean(p.imageUrl && p.imageUrl.includes("/api/pin"));
+}
+
+/** Force the 4:5 render (1080×1350) — IG rejects 2:3, and 4:5 suits FB too. */
+export function imageUrl4x5(p: PinSpec): string {
+  return `${p.imageUrl}&ar=4:5`;
+}
+
+/** Re-tag a pin's destination link for Facebook click attribution. */
+export function fbLink(p: PinSpec): string {
+  return p.link.replace(/utm_source=[^&]+&utm_medium=[^&]+/, "utm_source=facebook&utm_medium=social");
+}
+
+/**
+ * LRV → plain-language character, in the site's no-raw-numbers voice. High-LRV
+ * warm families (yellow/orange/red/brown) are off-whites in practice — Alabaster
+ * is family "yellow" but reads as a warm white; don't call those by their family.
+ */
+function characterNoun(lrv: number | null, family: string): string {
+  const warm = ["yellow", "orange", "red", "brown", "gold", "beige", "tan"];
+  if (lrv != null && lrv >= 73 && warm.includes(family)) return "warm white";
+  if (lrv != null && lrv >= 80 && ["gray", "neutral", "white", "", "color"].includes(family)) {
+    return "soft white";
+  }
+  return family && !["color", "guide", "swatch"].includes(family) ? family : "shade";
+}
+
+function colorCharacter(lrv: number | null, family: string): string {
+  const f = characterNoun(lrv, family);
+  if (lrv == null) return `a beautiful ${f}`;
+  if (lrv >= 70) return `a light, airy ${f}`;
+  if (lrv >= 55) return `a soft, versatile ${f}`;
+  if (lrv >= 40) return `a warm mid-tone ${f}`;
+  if (lrv >= 25) return `a rich, grounded ${f}`;
+  return `a deep, dramatic ${f}`;
+}
+
+export function hashtagsFor(p: PinSpec): string {
+  const generic = ["paintcolors", "paint", "interiordesign", "homedecor", "homeimprovement", "colorinspiration"];
+  const themeTag = (p.theme || "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+  const skip = new Set(["", "color", "swatch", "guide", "paint"]);
+  const tags = [...generic];
+  if (!skip.has(themeTag)) tags.push(`${themeTag}paint`);
+  return tags.map((t) => `#${t}`).join(" ");
+}
+
+/**
+ * Build a caption for the given network. Instagram can't have clickable links,
+ * so it points to the bio; Facebook gets the real (FB-attributed) destination.
+ */
+export function buildCaption(p: PinSpec, network: Network): string {
+  const isGuide = p.type !== "swatch";
+  const verb = isGuide
+    ? "Discover the colors, picture them in your space, and find where to buy"
+    : "See it in a real room and find the best place to buy it";
+  const cta =
+    network === "facebook"
+      ? `✨ ${verb}:\n${fbLink(p)}`
+      : `✨ ${verb} 👇\npaintcolorhq.com (link in bio)`;
+
+  let lead: string;
+  let body: string;
+  if (!isGuide) {
+    const params = new URL(p.imageUrl!).searchParams;
+    const name = params.get("name") ?? p.name;
+    const code = params.get("code") ?? "";
+    const lrvRaw = params.get("lrv");
+    const lrv = lrvRaw ? parseInt(lrvRaw, 10) : null;
+    const family = params.get("family") ?? p.theme;
+    lead = [params.get("brand") ?? "", name, code].filter(Boolean).join(" ");
+    const character = colorCharacter(lrv, family);
+    body = `${character.charAt(0).toUpperCase()}${character.slice(1)}${lrv != null ? ` (LRV ${lrv})` : ""}.`;
+  } else {
+    lead = p.name;
+    body = p.description;
+  }
+  return [lead, "", body, "", cta, "", hashtagsFor(p)].join("\n");
+}


### PR DESCRIPTION
## Summary
Adds a **Facebook Page** cross-poster — third leg of the social drip alongside Pinterest and Instagram, all driven by the same approved `QUEUE`. FB's advantage over IG: posts carry a **clickable link**, so this lane can actually drive traffic.

## Changes (scripts only — no deploy impact)
- **`social-content.ts`** (new) — shared caption + eligibility logic for both Meta networks. `buildCaption(pin, network)`: IG → "link in bio"; FB → the real `utm_source=facebook` clickable link. Keeps copy identical and on-message (discover → visualize → where-to-buy).
- **`facebook-publish.ts`** (new) — mints a **Page access token** from the Business system-user token (the system-user token itself gets Graph `#200` posting to a Page; its derived Page token works), then `POST /{PAGE_ID}/photos`. Separate `fb-published.json` ledger so a pin can post to Pinterest + IG + FB independently.
- **`instagram-publish.ts`** — refactored to import the shared helpers (no behavior change).
- **`scripts/facebook/`** — ledger (seeded with the inaugural post), `drip.sh`, plist template, installer. Scheduled 18:00 UTC, offset from Pinterest (14:00) and IG (16:00).

## Verified live
- Inaugural FB post (Agreeable Gray, with clickable link) ✅
- Full publisher run posted the Dunn-Edwards guide + wrote the ledger ✅
- IG + FB dry-runs render correct per-network CTAs ✅

## Test Plan
- [x] `--dry-run` renders correct captions for both networks
- [x] live FB post via the publisher succeeds and logs to `fb-published.json`
- [ ] `install-drip-schedule.sh` loads the agent (pending cadence decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)