### PR TITLE
chore(pinterest): spread the daily drip across 3 runs

### DIFF
--- a/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template
+++ b/scripts/pinterest/com.paintcolorhq.pinterest-drip.plist.template
@@ -16,8 +16,14 @@
   <dict>
     <key>PATH</key><string>__NODE_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
   </dict>
+  <!-- Spread ~6 pins/day across 3 runs (9am / 1pm / 5pm EDT) instead of one
+       burst — looks organic on Pinterest and catches more of the feed cycle. -->
   <key>StartCalendarInterval</key>
-  <dict><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+  <array>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+  </array>
   <key>StandardErrorPath</key><string>__REPO__/scripts/pinterest/drip.log</string>
   <key>RunAtLoad</key><false/>
 </dict>

--- a/scripts/pinterest/drip.sh
+++ b/scripts/pinterest/drip.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # launchd entry point for the Pinterest drip. Resolves the repo root from its
-# own location, then publishes the day's multi-board quota mix (--daily computes
-# the per-type quota by weekday). Logs to drip.log.
+# own location, then publishes 2 pins via the variety rotation. Fires 3×/day
+# (see the plist) to spread ~6 pins/day across the day instead of one burst.
+# Logs to drip.log.
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO"
 echo "=== drip run $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "$REPO/scripts/pinterest/drip.log"
-npx tsx scripts/pinterest-publish.ts --daily >> "$REPO/scripts/pinterest/drip.log" 2>&1
+npx tsx scripts/pinterest-publish.ts --drip=2 >> "$REPO/scripts/pinterest/drip.log" 2>&1


### PR DESCRIPTION
## Why
The Pinterest drip fired the entire daily quota in **one 14:00 UTC burst**. Posting ~5 pins at once is the clearest "automated" tell on Pinterest. Spreading them looks organic and catches more of the feed refresh cycle.

## Change (scripts only)
- `drip.sh`: `--daily` (whole quota at once) → `--drip=2` (2 pins via variety rotation per run).
- plist: single 14:00 fire → **3 fires at 13:00 / 17:00 / 21:00 UTC** (9am / 1pm / 5pm EDT) = ~6 pins/day, spread.
- `published.json` still dedupes, so the 3 runs never double-post.

Staggered against the other drips: Pinterest 9/1/5, Instagram noon, Facebook 2pm (EDT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)