### PR TITLE
feat(affiliate): accurate Samplize/Amazon/retailer links on color pages

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -223,7 +223,7 @@ export default async function ColorPage({ params }: PageProps) {
   // Curated, hand-written review for high-demand colors (null for the long tail).
   const curatedEditorial = getColorEditorial(brandSlug, colorSlug);
   const retailerLinks = getRetailerLinks(color.brand.slug, color.brand.name, color.name, color.color_number ?? undefined, color.color_family ?? undefined);
-  const sampleLinks = getSampleLinks({ brandName: color.brand.name, colorName: color.name, colorNumber: color.color_number });
+  const sampleLinks = getSampleLinks({ brandSlug: color.brand.slug, colorSlug: color.slug, brandName: color.brand.name, colorName: color.name, colorNumber: color.color_number });
   const harmonies = await resolveHarmonies(color.hex);
   const light = isLightColor(color.hex);
   const textClass = light ? "text-on-surface" : "text-on-primary";

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -12,7 +12,8 @@
 //     "https://shareasale.com/r.cfm?b=<bannerId>&u=<yourAffId>&m=<samplizeMerchantId>&urllink="
 //     The encoded Samplize URL is appended to it.
 //   NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG
-//     Your Amazon Associates store tag, e.g. "paintcolorhq-20".
+//     Amazon Associates store tag. Optional — defaults to the portfolio's
+//     active "greatpickdeal-20" when unset.
 //   NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX
 //     Home Depot affiliate (Impact) deep-link prefix ending right before the
 //     target URL — the existing homedepot.com link is appended, URL-encoded.
@@ -32,13 +33,19 @@ export interface SampleLink {
 }
 
 interface SampleInfo {
+  brandSlug: string;
+  colorSlug: string;
   brandName: string;
   colorName: string;
   colorNumber?: string | null;
 }
 
+/** Brands Samplize actually stocks peel-and-stick samples for. */
+const SAMPLIZE_BRANDS = new Set(["sherwin-williams", "benjamin-moore", "farrow-ball"]);
+
 const SAMPLIZE_PREFIX = process.env.NEXT_PUBLIC_SAMPLIZE_AFFILIATE_PREFIX;
-const AMAZON_TAG = process.env.NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG;
+// Amazon Associates tag. Defaults to the portfolio's active greatpickdeal-20.
+const AMAZON_TAG = process.env.NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG || "greatpickdeal-20";
 const HOMEDEPOT_PREFIX = process.env.NEXT_PUBLIC_HOMEDEPOT_AFFILIATE_PREFIX;
 const LOWES_PREFIX = process.env.NEXT_PUBLIC_LOWES_AFFILIATE_PREFIX;
 
@@ -70,24 +77,27 @@ export function getSampleLinks(info: SampleInfo): SampleLink[] {
   const query = [info.brandName, info.colorName].filter(Boolean).join(" ");
   const links: SampleLink[] = [];
 
-  // Samplize — peel-and-stick paint samples. The highest-intent action on a
-  // color page: someone researching a color wants to see it on their own wall.
-  const samplizeTarget = `https://www.samplize.com/search?q=${encodeURIComponent(query)}`;
-  links.push({
-    label: "Order a peel-and-stick sample",
-    url: SAMPLIZE_PREFIX ? `${SAMPLIZE_PREFIX}${encodeURIComponent(samplizeTarget)}` : samplizeTarget,
-    affiliate: Boolean(SAMPLIZE_PREFIX),
-    primary: true,
-  });
+  // Samplize — peel-and-stick samples. Only Sherwin-Williams, Benjamin Moore,
+  // and Farrow & Ball are stocked, and we deep-link straight to the color's
+  // product page (e.g. agreeable-gray-7029-12x12) — the highest-intent next
+  // step. The slug matches our colorSlug exactly (verified across all 3 brands).
+  if (SAMPLIZE_BRANDS.has(info.brandSlug) && info.colorSlug) {
+    const samplizeTarget = `https://samplize.com/products/${info.colorSlug}-12x12`;
+    links.push({
+      label: "Order a peel-and-stick sample",
+      url: SAMPLIZE_PREFIX ? `${SAMPLIZE_PREFIX}${encodeURIComponent(samplizeTarget)}` : samplizeTarget,
+      affiliate: Boolean(SAMPLIZE_PREFIX),
+      primary: true,
+    });
+  }
 
-  // Amazon — sample pots, swatch cards, and painting supplies.
-  const amazonUrl = `https://www.amazon.com/s?k=${encodeURIComponent(`${query} paint sample`)}${
-    AMAZON_TAG ? `&tag=${AMAZON_TAG}` : ""
-  }`;
+  // Amazon — sample pots, swatch cards, and painting supplies (all brands),
+  // tagged with the portfolio's active greatpickdeal-20 Associates tag.
+  const amazonUrl = `https://www.amazon.com/s?k=${encodeURIComponent(`${query} paint sample`)}&tag=${AMAZON_TAG}`;
   links.push({
     label: "Samples & supplies on Amazon",
     url: amazonUrl,
-    affiliate: Boolean(AMAZON_TAG),
+    affiliate: true,
   });
 
   return links;

--- a/src/lib/retailer-links.ts
+++ b/src/lib/retailer-links.ts
@@ -159,10 +159,20 @@ export function getRetailerLinks(
   if (!configs) return [];
 
   const info: ColorInfo = { brandName, colorName, colorNumber, colorFamily };
-  return configs
+  const links = configs
     .map((c) => ({
       retailerName: c.name,
       url: c.url(info),
     }))
     .filter((link) => link.url !== "");
+
+  // When a color is sold at Home Depot or Lowe's (our affiliate marketplaces),
+  // drop the manufacturer's own-site link — it's not an affiliate channel, so
+  // we send buyers to where we earn. Brands sold only at their own stores
+  // (SW, BM, Farrow & Ball, etc.) keep their link.
+  const MARKETPLACES = new Set(["Home Depot", "Lowe's"]);
+  if (links.some((l) => MARKETPLACES.has(l.retailerName))) {
+    return links.filter((l) => MARKETPLACES.has(l.retailerName));
+  }
+  return links;
 }


### PR DESCRIPTION
## Summary
Three monetization corrections on the color detail pages, per Philip:

1. **Samplize** — "Order a peel-and-stick sample" now appears **only for SW, Benjamin Moore, and Farrow & Ball** (the only brands Samplize stocks), and **deep-links to the exact product page** instead of a search: `samplize.com/products/{colorSlug}-12x12`. Our `colorSlug` matches Samplize's product handle exactly — **verified resolving (200) for SW, BM, and F&B**.
2. **Manufacturer link** — for brands sold at **Home Depot or Lowe's** (Behr, PPG, Valspar, Kilz, Glidden), the manufacturer's own-site "Buy at …" link is **dropped** (not an affiliate channel). Own-store brands (SW, BM, F&B, Dunn-Edwards, Dutch Boy→Menards) keep theirs.
3. **Amazon** — sample search links now carry the active **`greatpickdeal-20`** Associates tag on all brands.

## Behavior matrix (verified)
| Brand | Samplize | Retailer link |
|---|---|---|
| SW / BM / F&B | ✅ product deep-link | own store |
| Behr / PPG / Kilz / Glidden | ❌ | Home Depot only |
| Valspar | ❌ | Lowe's only |
| Dunn-Edwards / Dutch Boy | ❌ | own store / Menards |

## Notes
- `rel="sponsored nofollow noopener noreferrer"` on sample + affiliate retailer links is unchanged (already correct) — no SEO regression.
- Samplize stocks a curated catalog; a rare obscure SW/BM/F&B color could 404, but all trafficked colors resolve.
- Samplize/HD/Lowe's earn once their CJ/Impact deep-link prefixes are set in Vercel env; Amazon (greatpickdeal-20) is live now.

## Test Plan
- [x] logic verified across SW/BM/F&B/Behr/Valspar/Dunn-Edwards/Glidden
- [x] Samplize URLs resolve (200) for all three brands
- [x] `tsc --noEmit` clean on changed files
- [x] Amazon tag = greatpickdeal-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)