### PR TITLE
design(color page): split CTA cluster into tool vs shopping groups

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -437,23 +437,22 @@ export default async function ColorPage({ params }: PageProps) {
                 <div className="pt-5 border-t border-outline-variant/15">
                   <p className="text-xs font-semibold uppercase tracking-wider text-on-surface-variant mb-3">Get this color</p>
                   <div className="flex flex-wrap gap-3">
-                    {/* Sample-purchase CTAs (affiliate when configured) — highest-intent
-                        next step for a color page. rel="sponsored nofollow" per FTC/SEO. */}
-                    {sampleLinks.map((link) => (
-                      <a
-                        key={link.label}
-                        href={link.url}
-                        target="_blank"
-                        rel="sponsored nofollow noopener noreferrer"
-                        className={
-                          link.primary
-                            ? "bg-secondary text-on-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-secondary/20 hover:shadow-xl transition-all"
-                            : "bg-surface-container-highest text-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm border border-secondary/25 hover:shadow-md transition-all"
-                        }
-                      >
-                        {link.primary ? `${link.label} of ${color.name}` : link.label}
-                      </a>
-                    ))}
+                    {/* Order by monetization priority: Samplize hero (filled) →
+                        retailer (Home Depot/Lowe's, affiliate once live) → Amazon
+                        last. rel="sponsored nofollow" per FTC/SEO. */}
+                    {sampleLinks
+                      .filter((link) => link.primary)
+                      .map((link) => (
+                        <a
+                          key={link.label}
+                          href={link.url}
+                          target="_blank"
+                          rel="sponsored nofollow noopener noreferrer"
+                          className="bg-secondary text-on-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-secondary/20 hover:shadow-xl transition-all"
+                        >
+                          {`${link.label} of ${color.name}`}
+                        </a>
+                      ))}
                     {retailerLinks.map((link) => {
                       const a = affiliatizeRetailer(link.url);
                       return (
@@ -462,6 +461,19 @@ export default async function ColorPage({ params }: PageProps) {
                         </a>
                       );
                     })}
+                    {sampleLinks
+                      .filter((link) => !link.primary)
+                      .map((link) => (
+                        <a
+                          key={link.label}
+                          href={link.url}
+                          target="_blank"
+                          rel="sponsored nofollow noopener noreferrer"
+                          className="bg-surface-container-highest text-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm border border-secondary/25 hover:shadow-md transition-all"
+                        >
+                          {link.label}
+                        </a>
+                      ))}
                   </div>
                   {AFFILIATE_ENABLED && (
                     <p className="mt-4 text-xs text-on-surface-variant">

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -448,7 +448,7 @@ export default async function ColorPage({ params }: PageProps) {
                         className={
                           link.primary
                             ? "bg-secondary text-on-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-secondary/20 hover:shadow-xl transition-all"
-                            : "bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/30 hover:shadow-md transition-all"
+                            : "bg-surface-container-highest text-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm border border-secondary/25 hover:shadow-md transition-all"
                         }
                       >
                         {link.primary ? `${link.label} of ${color.name}` : link.label}
@@ -457,7 +457,7 @@ export default async function ColorPage({ params }: PageProps) {
                     {retailerLinks.map((link) => {
                       const a = affiliatizeRetailer(link.url);
                       return (
-                        <a key={link.retailerName} href={a.url} target="_blank" rel={`${a.affiliate ? "sponsored " : ""}nofollow noopener noreferrer`} className="bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/30 hover:shadow-md transition-all">
+                        <a key={link.retailerName} href={a.url} target="_blank" rel={`${a.affiliate ? "sponsored " : ""}nofollow noopener noreferrer`} className="bg-surface-container-highest text-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm border border-secondary/25 hover:shadow-md transition-all">
                           Buy at {link.retailerName}
                         </a>
                       );

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -416,44 +416,61 @@ export default async function ColorPage({ params }: PageProps) {
                 <Link href={`/brands/${color.brand.slug}`} className="font-headline font-bold text-primary hover:underline">{color.brand.name}</Link>
               </div>
             </div>
-            <div className="flex flex-wrap gap-3">
-              <TrackedLink href={`/tools/palette-generator?hex=${encodeURIComponent(color.hex)}`} className="bg-gradient-to-br from-primary to-primary-container text-on-primary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-primary/20" eventName="cta_click" eventParams={{ cta_label: "generate_palette", color_name: color.name, color_brand: color.brand.slug }}>
-                Generate Palette
-              </TrackedLink>
-              <TrackedLink href={`/compare?color1=${color.id}`} className="bg-surface-container-highest text-primary px-6 py-3 rounded-xl font-headline font-bold text-sm" eventName="cta_click" eventParams={{ cta_label: "compare", color_name: color.name, color_brand: color.brand.slug }}>
-                Compare
-              </TrackedLink>
-              {/* Sample-purchase CTAs (affiliate when configured) — highest-intent
-                  next step for a color page. rel="sponsored nofollow" per FTC/SEO. */}
-              {sampleLinks.map((link) => (
-                <a
-                  key={link.label}
-                  href={link.url}
-                  target="_blank"
-                  rel="sponsored nofollow noopener noreferrer"
-                  className={
-                    link.primary
-                      ? "bg-gradient-to-br from-primary to-primary-container text-on-primary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-primary/20 hover:shadow-xl transition-all"
-                      : "bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/15 hover:shadow-md transition-all"
-                  }
-                >
-                  {link.primary ? `${link.label} of ${color.name}` : link.label}
-                </a>
-              ))}
-              {retailerLinks.map((link) => {
-                const a = affiliatizeRetailer(link.url);
-                return (
-                  <a key={link.retailerName} href={a.url} target="_blank" rel={`${a.affiliate ? "sponsored " : ""}nofollow noopener noreferrer`} className="bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/15 hover:shadow-md transition-all">
-                    Buy at {link.retailerName}
-                  </a>
-                );
-              })}
+            {/* Two labeled groups so the color language reads cleanly:
+                blue = explore (site tools), teal = the primary buy action,
+                outlined-neutral = secondary buy options. One filled hero per
+                group. */}
+            <div className="space-y-5">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-on-surface-variant mb-3">Use this color</p>
+                <div className="flex flex-wrap gap-3">
+                  <TrackedLink href={`/tools/palette-generator?hex=${encodeURIComponent(color.hex)}`} className="bg-gradient-to-br from-primary to-primary-container text-on-primary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-primary/20 hover:shadow-xl transition-all" eventName="cta_click" eventParams={{ cta_label: "generate_palette", color_name: color.name, color_brand: color.brand.slug }}>
+                    Generate Palette
+                  </TrackedLink>
+                  <TrackedLink href={`/compare?color1=${color.id}`} className="bg-surface-container-highest text-primary px-6 py-3 rounded-xl font-headline font-bold text-sm border border-primary/20 hover:shadow-md transition-all" eventName="cta_click" eventParams={{ cta_label: "compare", color_name: color.name, color_brand: color.brand.slug }}>
+                    Compare
+                  </TrackedLink>
+                </div>
+              </div>
+
+              {(sampleLinks.length > 0 || retailerLinks.length > 0) && (
+                <div className="pt-5 border-t border-outline-variant/15">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-on-surface-variant mb-3">Get this color</p>
+                  <div className="flex flex-wrap gap-3">
+                    {/* Sample-purchase CTAs (affiliate when configured) — highest-intent
+                        next step for a color page. rel="sponsored nofollow" per FTC/SEO. */}
+                    {sampleLinks.map((link) => (
+                      <a
+                        key={link.label}
+                        href={link.url}
+                        target="_blank"
+                        rel="sponsored nofollow noopener noreferrer"
+                        className={
+                          link.primary
+                            ? "bg-secondary text-on-secondary px-6 py-3 rounded-xl font-headline font-bold text-sm shadow-lg shadow-secondary/20 hover:shadow-xl transition-all"
+                            : "bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/30 hover:shadow-md transition-all"
+                        }
+                      >
+                        {link.primary ? `${link.label} of ${color.name}` : link.label}
+                      </a>
+                    ))}
+                    {retailerLinks.map((link) => {
+                      const a = affiliatizeRetailer(link.url);
+                      return (
+                        <a key={link.retailerName} href={a.url} target="_blank" rel={`${a.affiliate ? "sponsored " : ""}nofollow noopener noreferrer`} className="bg-surface-container-lowest text-on-surface px-6 py-3 rounded-xl font-headline font-bold text-sm border border-outline-variant/30 hover:shadow-md transition-all">
+                          Buy at {link.retailerName}
+                        </a>
+                      );
+                    })}
+                  </div>
+                  {AFFILIATE_ENABLED && (
+                    <p className="mt-4 text-xs text-on-surface-variant">
+                      Some sample and supply links are affiliate links — if you buy through them, Paint Color HQ may earn a small commission at no extra cost to you. It helps keep the site free.
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
-            {AFFILIATE_ENABLED && (
-              <p className="mt-4 text-xs text-on-surface-variant">
-                Some sample and supply links are affiliate links — if you buy through them, Paint Color HQ may earn a small commission at no extra cost to you. It helps keep the site free.
-              </p>
-            )}
           </div>
 
           <div className="lg:col-span-7">


### PR DESCRIPTION
## Why
The color-page CTA cluster felt cramped, and the coloring didn't map to meaning — two identical loud-blue buttons (Generate Palette *and* Order a sample) competed, while Compare/Amazon/Buy floated as white boxes.

## Change
Split into two labeled, separated groups with a clear color language:
- **"Use this color"** (site tools): Generate Palette (filled blue) + Compare (outlined blue).
- **"Get this color"** (shopping): primary sample CTA filled **teal** (`secondary` token); Amazon + retailer outlined-neutral. Divider + spacing above it.

**Color now maps to meaning:** blue = explore, teal = buy, outlined = alternative buy options. One filled hero per group.

Shopping group only renders when there are sample/retailer links. `rel` attributes unchanged.

## Test Plan
- [x] `tsc --noEmit` clean on the color page
- [ ] Visual review on the preview deploy (SW color = teal Samplize hero; Behr = no Samplize, HD outlined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)