### PR TITLE
perf(isr): raise revalidate on static routes to cut ISR Writes

### DIFF
--- a/src/app/brands/[brandSlug]/page.tsx
+++ b/src/app/brands/[brandSlug]/page.tsx
@@ -16,7 +16,7 @@ import { ColorLinkEnhancer } from "@/components/color-link-enhancer";
 import { getPostsByBrand } from "@/lib/blog-posts";
 import Image from "next/image";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 export async function generateStaticParams() {
   const brands = await getAllBrands();

--- a/src/app/brands/page.tsx
+++ b/src/app/brands/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/footer";
 import { AdSenseScript } from "@/components/adsense-script";
 import { getAllBrands, getColorsByBrand } from "@/lib/queries";
 
-export const revalidate = 3600;
+export const revalidate = 604800; // 7d — static index page
 
 export const metadata: Metadata = {
   title: "Paint Brand Directory — 14 Brands, 23,000+ Colors",

--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -22,7 +22,7 @@ import { TrackedLink } from "@/components/tracked-link";
 import { PairingSelector } from "@/components/pairing-selector";
 import { POPULAR_COLOR_SLUGS } from "@/lib/popular-colors";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 // Pre-render popular colors at build time; all others are generated on
 // demand and cached via ISR (revalidate=3600) on first visit. Without

--- a/src/app/colors/family/[familySlug]/page.tsx
+++ b/src/app/colors/family/[familySlug]/page.tsx
@@ -14,7 +14,7 @@ import { getPaletteBySlug } from "@/lib/palettes";
 import { TrackPage } from "@/components/track-page";
 import { ColorLinkEnhancer } from "@/components/color-link-enhancer";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 const validFamilies = [
   "red", "orange", "yellow", "green", "blue", "purple", "pink",

--- a/src/app/colors/page.tsx
+++ b/src/app/colors/page.tsx
@@ -4,7 +4,7 @@ import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { getAllColorFamilies } from "@/lib/queries";
 
-export const revalidate = 3600;
+export const revalidate = 604800; // 7d — static index page
 
 export const metadata: Metadata = {
   title: "Browse Paint Colors by Color Family",

--- a/src/app/inspiration/[slug]/page.tsx
+++ b/src/app/inspiration/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { getAllBrands, findClosestColor, getBrandBySlug } from "@/lib/queries";
 import type { ColorWithBrand } from "@/lib/types";
 import { AdSenseScript } from "@/components/adsense-script";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 export function generateStaticParams() {
   return inspirationPalettes.map((p) => ({ slug: p.slug }));

--- a/src/app/inspiration/page.tsx
+++ b/src/app/inspiration/page.tsx
@@ -7,7 +7,7 @@ import { inspirationPalettes } from "@/lib/palettes";
 import { findClosestColor } from "@/lib/queries";
 import type { ColorWithBrand } from "@/lib/types";
 
-export const revalidate = 3600;
+export const revalidate = 604800; // 7d — static index page
 
 export const metadata: Metadata = {
   title: "Color Inspiration",

--- a/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/[matchSlug]/page.tsx
@@ -9,7 +9,7 @@ import { TrackPage } from "@/components/track-page";
 import { getColorBySlug, getCrossBrandMatches, getBrandBySlug } from "@/lib/queries";
 import { POPULAR_COLOR_SLUGS, MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 // Without generateStaticParams Next.js 16 falls back to fully dynamic SSR for
 // dynamic route segments — `revalidate` alone doesn't opt the route into ISR.

--- a/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
+++ b/src/app/match/[sourceBrandSlug]/to/[targetBrandSlug]/page.tsx
@@ -11,7 +11,7 @@ import { getBrandBySlug, getTopCrossBrandMatches } from "@/lib/queries";
 import { MAJOR_MATCH_BRANDS } from "@/lib/popular-colors";
 import { getBrandPairIntro } from "@/lib/brand-pair-intros";
 
-export const revalidate = 3600;
+export const revalidate = 2592000; // 30d — static color/match/brand data; redeploys pick up data changes
 
 const MAJOR_BRANDS = MAJOR_MATCH_BRANDS;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,7 +82,7 @@ const tools = [
   },
 ];
 
-export const revalidate = 3600;
+export const revalidate = 604800; // 7d — static index page
 
 const faqItems = [
   {


### PR DESCRIPTION
## Why
Vercel blew past the \$20 credit 22 days early. **ISR Writes was \$10.78 (half the bill)** + most of the \$3.69 Fluid CPU. Root cause: every route on `revalidate = 3600` (hourly), so all **23,000+ static color pages** regenerate hourly as crawlers (Bing especially) trip the window.

## Change
Color/match/brand data is static, so:
- **Detail pages → 30 days** (`2592000`): color, family, match (both), brand, inspiration
- **Index pages → 7 days** (`604800`): homepage, colors, brands, inspiration
- **Kept at hourly** (`3600`): blog list + post (future-dated posts reveal via hourly ISR) and the two sitemap routes (must surface revealed posts on the same cadence)

Cuts color-page regenerations **~720×** (hourly → monthly). Env/data changes still propagate on the next redeploy. Optional follow-up: on-demand `revalidatePath` from the seed scripts.

## Test Plan
- [x] `tsc --noEmit` clean (no src errors)
- [ ] After deploy: confirm color pages still serve + ISR Writes drop next cycle
- [ ] Confirm a scheduled blog post still reveals on its date (blog stayed at 3600)

🤖 Generated with [Claude Code](https://claude.com/claude-code)