### PR TITLE
fix(a11y): darken --outline token to pass WCAG AA contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ scripts/pinterest/published*.json
 scripts/pinterest/drip.log
 scripts/pinterest/analytics.log
 scripts/pinterest/reports/
+
+# Social drip run logs (runtime-only; the published.json ledgers ARE tracked)
+scripts/facebook/drip.log
+scripts/instagram/drip.log

--- a/scripts/facebook/fb-published.json
+++ b/scripts/facebook/fb-published.json
@@ -6,5 +6,21 @@
   "guide-best-dunn-edwards-paint-colors": {
     "postId": "996679250203039_122116669310980879",
     "publishedAt": "2026-06-05T06:11:10.191Z"
+  },
+  "swatch-vista-paint-mystic-fog-c-18": {
+    "postId": "996679250203039_122116851368980879",
+    "publishedAt": "2026-06-06T22:00:19.992Z"
+  },
+  "swatch-dunn-edwards-faded-gray-dew382": {
+    "postId": "996679250203039_122117059424980879",
+    "publishedAt": "2026-06-08T22:00:16.231Z"
+  },
+  "swatch-benjamin-moore-mortar-cc-574": {
+    "postId": "996679250203039_122117285120980879",
+    "publishedAt": "2026-06-10T22:00:10.794Z"
+  },
+  "guide-best-behr-paint-colors": {
+    "postId": "996679250203039_122117393210980879",
+    "publishedAt": "2026-06-11T22:00:18.281Z"
   }
 }

--- a/scripts/instagram/ig-published.json
+++ b/scripts/instagram/ig-published.json
@@ -1,1 +1,30 @@
-{}
+{
+  "swatch-sherwin-williams-agreeable-gray-7029": {
+    "mediaId": "18325863958280530",
+    "publishedAt": "2026-06-05T06:03:54.827Z"
+  },
+  "guide-best-dunn-edwards-paint-colors": {
+    "mediaId": "17988905942814164",
+    "publishedAt": "2026-06-06T20:00:17.500Z"
+  },
+  "swatch-vista-paint-mystic-fog-c-18": {
+    "mediaId": "18176462695415015",
+    "publishedAt": "2026-06-07T20:00:15.225Z"
+  },
+  "swatch-dunn-edwards-faded-gray-dew382": {
+    "mediaId": "17931271308290845",
+    "publishedAt": "2026-06-08T20:08:51.212Z"
+  },
+  "swatch-benjamin-moore-mortar-cc-574": {
+    "mediaId": "17942579913230153",
+    "publishedAt": "2026-06-09T20:00:11.185Z"
+  },
+  "guide-best-behr-paint-colors": {
+    "mediaId": "18101632417874026",
+    "publishedAt": "2026-06-10T20:00:23.927Z"
+  },
+  "swatch-benjamin-moore-vapor-af-35": {
+    "mediaId": "18103986038103098",
+    "publishedAt": "2026-06-11T20:00:10.914Z"
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,7 +43,8 @@
   --on-surface: #161935;
   --on-surface-variant: #434655;
   --on-background: #161935;
-  --outline: #737686;
+  /* WCAG AA: must hold >=4.5:1 as small text on every surface tier (darkest: surface-container-highest #dfe0ff) */
+  --outline: #5e616e;
   --outline-variant: #c3c6d7;
 
   /* Inverse */


### PR DESCRIPTION
## Summary
- Lighthouse accessibility audit flagged every `text-outline` element for insufficient color contrast (nav search placeholder, hero swatch label, data disclaimer, FAQ secondary text)
- Root cause: `--outline: #737686` hits only 4.28:1 on `bg-surface` and 4.07:1 on `surface-container-low` — below the 4.5:1 WCAG AA threshold for small text
- Darkened the token to `#5e616e` (same slate hue): passes 4.5:1 on all six surface tiers, worst case 4.76:1 on `surface-container-highest`
- One-token fix covers all 36 files using `text-outline`; the ~125 `border-outline` hairlines get one shade darker, which also helps the 3:1 non-text contrast target

## Also in this PR
- Latest FB/IG drip publish ledgers (routine runtime state, load-bearing for duplicate prevention)
- Gitignore the social drip run logs (`scripts/facebook/drip.log`, `scripts/instagram/drip.log`)

## Verification
- Contrast ratios computed per WCAG relative-luminance formula for the new value against every surface token
- Re-run Lighthouse on the preview deploy to confirm the contrast audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)