### PR TITLE
fix(seed-matches): abort before insert if clear step left rows behind

### DIFF
--- a/scripts/seed-matches.ts
+++ b/scripts/seed-matches.ts
@@ -78,9 +78,13 @@ async function main() {
   let offset = 0;
   const PAGE_SIZE = 1000;
   while (true) {
+    // ORDER BY is load-bearing: .range() pagination without a stable sort
+    // returns nondeterministic page boundaries, which dropped ~38% of colors
+    // from the lookup and silently skipped ~910K match rows per run.
     const { data: colorPage, error: colorErr } = await supabase
       .from("colors")
       .select("id, slug, brand_id")
+      .order("id", { ascending: true })
       .range(offset, offset + PAGE_SIZE - 1);
 
     if (colorErr) {
@@ -102,6 +106,16 @@ async function main() {
   }
 
   console.log(`  ${colorUuidMap.size} color UUIDs loaded`);
+
+  const { count: colorCount } = await supabase
+    .from("colors")
+    .select("*", { count: "exact", head: true });
+  if (colorCount !== null && colorUuidMap.size !== colorCount) {
+    console.error(
+      `Color lookup incomplete: ${colorUuidMap.size} loaded vs ${colorCount} in DB. Aborting.`,
+    );
+    process.exit(1);
+  }
 
   // Step 2: Resolve slug references to UUIDs
   console.log("Resolving match references...");

--- a/scripts/seed-matches.ts
+++ b/scripts/seed-matches.ts
@@ -157,7 +157,7 @@ async function main() {
       .select("id");
 
     if (deleteErr) {
-      console.log("  Delete batch error (continuing):", deleteErr.message);
+      console.error("  Delete batch error:", deleteErr.message);
       break;
     }
     if (!deleted || deleted.length === 0) break;
@@ -165,6 +165,20 @@ async function main() {
     if (deleteTotal % 50000 === 0) console.log(`  Deleted ${deleteTotal} rows...`);
   }
   console.log(`  Cleared ${deleteTotal} existing matches.`);
+
+  // Inserting into a non-empty table stacks fresh matches on top of stale
+  // ones (this happened: a statement timeout cleared 0 of 1.5M rows and the
+  // script kept going). Verify the clear actually worked before inserting.
+  const { count: remaining, error: countErr } = await supabase
+    .from("cross_brand_matches")
+    .select("*", { count: "exact", head: true });
+  if (countErr || (remaining ?? 0) > 0) {
+    console.error(
+      `Table not empty after clear (${remaining ?? "unknown"} rows remain). ` +
+        "Truncate cross_brand_matches manually, then re-run. Aborting before insert.",
+    );
+    process.exit(1);
+  }
 
   // Step 4: Insert in batches
   const BATCH_SIZE = 500;


### PR DESCRIPTION
## Summary
During the PR #123 dedupe reseed, the clear step in `seed-matches.ts` hit a Postgres statement timeout, deleted 0 of ~1.5M rows, logged "continuing", and inserted 573K fresh matches on top of the stale ones. Recovered by truncating server-side and re-running.

This adds a guard: after the clear loop, count the table and abort before inserting if any rows remain.

Script-only change (`scripts/` is excluded from Vercel builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)