### PR TITLE
feat(import): Behr live-palette import — 1,249 missing colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "build-match-data": "tsx scripts/build-match-data.ts",
     "dedupe-colors": "tsx scripts/dedupe-colors.ts",
     "export-db-colors": "tsx scripts/export-db-colors.ts",
+    "import-behr-live": "tsx scripts/import-behr-live.ts",
     "research-colors": "tsx scripts/blog/research-colors.ts",
     "verify-links": "tsx scripts/blog/verify-links.ts",
     "indexnow-blog": "tsx scripts/blog/indexnow-submit.ts",
     "test:pinterest": "node --import tsx --test scripts/pinterest/queue.test.ts",
     "test:blog": "node --import tsx --test scripts/blog/*.test.ts",
-    "test:dedupe": "node --import tsx --test scripts/lib/dedupe-rules.test.ts"
+    "test:dedupe": "node --import tsx --test scripts/lib/dedupe-rules.test.ts",
+    "test:behr-import": "node --import tsx --test scripts/lib/behr-import-rules.test.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.6.1",

--- a/scripts/import-behr-live.ts
+++ b/scripts/import-behr-live.ts
@@ -1,0 +1,188 @@
+/**
+ * Import missing Behr colors from the live-palette dump captured off
+ * behr.com/consumer/colors/paint (window.colorData, saved as
+ * data/behr-live-palette.json).
+ *
+ * Filters out spray/gloss entries and anything already in the DB (matched
+ * by color_number OR slug), then inserts the rest with the same derived
+ * fields (family, LRV, Lab) the colornerd import computes.
+ *
+ * Usage:
+ *   tsx scripts/import-behr-live.ts          # dry run: writes data/behr-import-plan.json
+ *   tsx scripts/import-behr-live.ts --apply  # insert into the DB
+ *
+ * After applying, fold the new colors into cross-brand matches:
+ *   npm run export-db-colors && npm run compute-matches && npm run seed-matches
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import {
+  parseLivePalette,
+  shouldImport,
+  titleCaseName,
+  makeSlug,
+  type LivePaletteRaw,
+} from './lib/behr-import-rules';
+import {
+  classifyColorFamily,
+  calculateLrv,
+  rgbToLab,
+  hexToRgb,
+} from './lib/color-math';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
+
+const PALETTE_FILE = path.resolve(__dirname, '../data/behr-live-palette.json');
+const PLAN_FILE = path.resolve(__dirname, '../data/behr-import-plan.json');
+const APPLY = process.argv.includes('--apply');
+const BATCH_SIZE = 500;
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
+    process.exit(1);
+  }
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  if (!fs.existsSync(PALETTE_FILE)) {
+    console.error(`Palette dump not found: ${PALETTE_FILE}`);
+    console.error('Capture window.colorData from behr.com/consumer/colors/paint first.');
+    process.exit(1);
+  }
+  let raw: LivePaletteRaw | string = JSON.parse(fs.readFileSync(PALETTE_FILE, 'utf8'));
+  if (typeof raw === 'string') raw = JSON.parse(raw) as LivePaletteRaw; // double-encoded dump
+
+  const live = parseLivePalette(raw);
+  const importable = live.filter(shouldImport);
+  console.log(`Live palette: ${live.length} unique ids, ${importable.length} importable wall-paint colors`);
+
+  // --- Existing Behr rows ---------------------------------------------------
+  const { data: brand, error: brandErr } = await supabase
+    .from('brands')
+    .select('id, slug')
+    .eq('slug', 'behr')
+    .single();
+  if (brandErr || !brand) {
+    console.error('Failed to fetch behr brand:', brandErr?.message);
+    process.exit(1);
+  }
+
+  const existingNumbers = new Set<string>();
+  const existingSlugs = new Set<string>();
+  let offset = 0;
+  const PAGE = 1000;
+  for (;;) {
+    const { data: page, error } = await supabase
+      .from('colors')
+      .select('color_number, slug')
+      .eq('brand_id', brand.id)
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    if (error) {
+      console.error('Failed to fetch existing colors:', error.message);
+      process.exit(1);
+    }
+    if (!page || page.length === 0) break;
+    for (const c of page) {
+      if (c.color_number) existingNumbers.add(String(c.color_number).toUpperCase());
+      existingSlugs.add(c.slug);
+    }
+    offset += page.length;
+    if (page.length < PAGE) break;
+  }
+  console.log(`Existing Behr rows: ${existingSlugs.size} (${existingNumbers.size} distinct numbers)`);
+
+  // --- Build insert rows ----------------------------------------------------
+  const rows = [];
+  let skippedExisting = 0;
+  const slugCollisions: string[] = [];
+  for (const c of importable) {
+    if (existingNumbers.has(c.id)) {
+      skippedExisting++;
+      continue;
+    }
+    const name = titleCaseName(c.name);
+    const slug = makeSlug(name, c.id);
+    if (existingSlugs.has(slug)) {
+      // Same name+number shape already in DB under a different/absent
+      // color_number — never silently overwrite, list for manual review.
+      slugCollisions.push(slug);
+      continue;
+    }
+    const rgb = hexToRgb(c.hex)!;
+    const lab = rgbToLab(rgb.r, rgb.g, rgb.b);
+    rows.push({
+      brand_id: brand.id,
+      name,
+      slug,
+      color_number: c.id,
+      hex: c.hex,
+      rgb_r: rgb.r,
+      rgb_g: rgb.g,
+      rgb_b: rgb.b,
+      lab_l: lab.l,
+      lab_a: lab.a,
+      lab_b_val: lab.b_val,
+      lrv: Math.round(calculateLrv(rgb.r, rgb.g, rgb.b) * 10) / 10,
+      color_family: classifyColorFamily(rgb.r, rgb.g, rgb.b),
+    });
+  }
+
+  console.log(`To import: ${rows.length} (already in DB: ${skippedExisting}, slug collisions: ${slugCollisions.length})`);
+  if (slugCollisions.length) {
+    console.log('Slug collisions (NOT imported, review manually):');
+    for (const s of slugCollisions) console.log(`  ${s}`);
+  }
+  const familyDist = rows.reduce<Record<string, number>>((acc, r) => {
+    acc[r.color_family] = (acc[r.color_family] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log('Family distribution:', familyDist);
+
+  fs.writeFileSync(PLAN_FILE, JSON.stringify({ slugCollisions, rows }, null, 1));
+  console.log(`Plan written: ${PLAN_FILE}`);
+
+  if (!APPLY) {
+    console.log('\nDry run — no DB changes. Re-run with --apply to insert.');
+    return;
+  }
+
+  // --- Insert ---------------------------------------------------------------
+  let inserted = 0;
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    const { error } = await supabase.from('colors').insert(batch);
+    if (error) {
+      console.error(`Insert failed at batch ${i} (${inserted} already inserted):`, error.message);
+      process.exit(1);
+    }
+    inserted += batch.length;
+    console.log(`  ${inserted}/${rows.length} inserted`);
+  }
+
+  const { count } = await supabase
+    .from('colors')
+    .select('*', { count: 'exact', head: true })
+    .eq('brand_id', brand.id);
+  if (count !== null) {
+    const { error: updErr } = await supabase
+      .from('brands')
+      .update({ color_count: count })
+      .eq('id', brand.id);
+    if (updErr) console.error('brands.color_count update failed:', updErr.message);
+    else console.log(`brands.color_count updated: ${count}`);
+  }
+
+  console.log(`\nDone. Inserted ${inserted} Behr colors. Now recompute matches:`);
+  console.log('  npm run export-db-colors && npm run compute-matches && npm run seed-matches');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/lib/behr-import-rules.test.ts
+++ b/scripts/lib/behr-import-rules.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseLivePalette,
+  shouldImport,
+  titleCaseName,
+  makeSlug,
+  type LiveColor,
+} from './behr-import-rules';
+import { classifyColorFamily, calculateLrv, rgbToLab, hexToRgb } from './color-math';
+
+const color = (over: Partial<LiveColor>): LiveColor => ({
+  id: 'S350-4A',
+  name: 'DRIED ROSEMARY',
+  hex: '#a7a07e',
+  isLegacy: false,
+  ...over,
+});
+
+test('spray ids and GLOSS names are excluded', () => {
+  assert.equal(shouldImport(color({ id: '6794', name: 'SILVER GRAY - GLOSS' })), false);
+  assert.equal(shouldImport(color({ id: '6694', name: 'SILVER GRAY' })), false);
+  assert.equal(shouldImport(color({})), true);
+});
+
+test('classic ready-mix whites (numeric ids) are kept', () => {
+  assert.equal(shouldImport(color({ id: '12', name: 'SWISS COFFEE', hex: '#f3f2e6' })), true);
+  assert.equal(shouldImport(color({ id: '1850', name: 'ULTRA PURE WHITE', hex: '#ffffff' })), true);
+});
+
+test('legacy and malformed-hex entries are excluded', () => {
+  assert.equal(shouldImport(color({ isLegacy: true })), false);
+  assert.equal(shouldImport(color({ hex: 'rgb(1,2,3)' })), false);
+});
+
+test('parseLivePalette dedupes repeated ids', () => {
+  const raw = {
+    header: ['id', 'name', 'rgb', 'islegacycolor'],
+    count: 3,
+    rows: [
+      ['52', 'WHITE', '#FFFFFF', 'false'],
+      ['52', 'WHITE', '#FFFFFF', 'false'],
+      ['DC-001', 'WHIPPED CREAM', '#F6F5EF', 'false'],
+    ],
+  };
+  const parsed = parseLivePalette(raw);
+  assert.equal(parsed.length, 2);
+  assert.deepEqual(parsed.map((c) => c.id), ['52', 'DC-001']);
+  assert.equal(parsed[1].hex, '#f6f5ef');
+});
+
+test('titleCaseName lowercases small words but not the first word', () => {
+  assert.equal(titleCaseName('PEACH OF MIND'), 'Peach of Mind');
+  assert.equal(titleCaseName('THE REAL TEAL'), 'The Real Teal');
+  assert.equal(titleCaseName('SEMI-SWEET'), 'Semi-Sweet');
+});
+
+test('makeSlug matches the existing DB slug shape', () => {
+  assert.equal(makeSlug('Dried Rosemary', 'S350-4A'), 'dried-rosemary-s350-4a');
+  assert.equal(makeSlug('Whipped Cream', 'DC-001'), 'whipped-cream-dc-001');
+  assert.equal(makeSlug("Will O' The Wisp", '23'), 'will-o-the-wisp-23');
+});
+
+test('color math reproduces the manually-verified Dried Rosemary row', () => {
+  const rgb = hexToRgb('#A7A07E')!;
+  assert.deepEqual(rgb, { r: 167, g: 160, b: 126 });
+  assert.equal(classifyColorFamily(rgb.r, rgb.g, rgb.b), 'neutral');
+  assert.equal(Math.round(calculateLrv(rgb.r, rgb.g, rgb.b) * 10) / 10, 34.9);
+  const lab = rgbToLab(rgb.r, rgb.g, rgb.b);
+  assert.ok(Math.abs(lab.l - 65.64) < 0.05, `lab.l=${lab.l}`);
+  assert.ok(Math.abs(lab.a - -3.08) < 0.05, `lab.a=${lab.a}`);
+  assert.ok(Math.abs(lab.b_val - 18.68) < 0.05, `lab.b=${lab.b_val}`);
+});

--- a/scripts/lib/behr-import-rules.ts
+++ b/scripts/lib/behr-import-rules.ts
@@ -1,0 +1,90 @@
+/**
+ * Filter + normalization rules for importing colors from Behr's live palette
+ * dump (window.colorData on behr.com/consumer/colors/paint, saved to
+ * data/behr-live-palette.json).
+ *
+ * The dump is row-arrays with a header row of field names. It contains the
+ * full retail palette plus a handful of spray-paint entries and duplicate
+ * rows for the classic ready-mix whites — the rules here decide what is a
+ * wall-paint color worth importing.
+ */
+
+export interface LivePaletteRaw {
+  header: string[];
+  count: number;
+  rows: (string | number | boolean | null)[][];
+}
+
+export interface LiveColor {
+  id: string; // color number, e.g. "S350-4A", "DC-001", "12"
+  name: string; // raw name from Behr, ALL CAPS
+  hex: string; // "#A7A07E"
+  isLegacy: boolean;
+}
+
+/**
+ * Behr's spray-paint line: the two "- GLOSS" entries and their flat
+ * siblings. These are the only numeric ids that aren't classic ready-mix
+ * wall whites (12 Swiss Coffee, 1850 Ultra Pure White, etc.).
+ */
+const SPRAY_IDS = new Set(['6694', '6695', '6794', '6795']);
+
+export function parseLivePalette(raw: LivePaletteRaw): LiveColor[] {
+  const idx = new Map(raw.header.map((k, i) => [k, i]));
+  const need = ['id', 'name', 'rgb', 'islegacycolor'];
+  for (const k of need) {
+    if (!idx.has(k)) throw new Error(`Palette dump missing field: ${k}`);
+  }
+  const out: LiveColor[] = [];
+  const seen = new Set<string>();
+  for (const row of raw.rows) {
+    const id = String(row[idx.get('id')!] ?? '').trim().toUpperCase();
+    if (!id || seen.has(id)) continue; // dump repeats the classic whites
+    seen.add(id);
+    out.push({
+      id,
+      name: String(row[idx.get('name')!] ?? '').trim(),
+      hex: String(row[idx.get('rgb')!] ?? '').trim().toLowerCase(),
+      isLegacy: String(row[idx.get('islegacycolor')!]) === 'true',
+    });
+  }
+  return out;
+}
+
+/** True if this palette entry is an importable wall-paint color. */
+export function shouldImport(c: LiveColor): boolean {
+  if (c.isLegacy) return false;
+  if (SPRAY_IDS.has(c.id)) return false;
+  if (/\bGLOSS\b/i.test(c.name)) return false;
+  if (!/^#[0-9a-f]{6}$/.test(c.hex)) return false;
+  if (!c.name) return false;
+  return true;
+}
+
+const SMALL_WORDS = new Set([
+  'a', 'an', 'and', 'at', 'but', 'by', 'for', 'in', 'of', 'on', 'or',
+  'the', 'to', 'with',
+]);
+
+/** "PEACH OF MIND" -> "Peach of Mind"; first word always capitalized. */
+export function titleCaseName(raw: string): string {
+  const words = raw.toLowerCase().split(/\s+/).filter(Boolean);
+  return words
+    .map((w, i) => {
+      if (i > 0 && SMALL_WORDS.has(w)) return w;
+      // capitalize first letter and any letter after a hyphen/apostrophe
+      // boundary start ("semi-sweet" -> "Semi-Sweet")
+      return w.replace(/(^|[-'])([a-z])/g, (_, p, ch) => p + ch.toUpperCase());
+    })
+    .join(' ');
+}
+
+/** Same slug shape the colornerd import produces: name slug + number slug. */
+export function makeSlug(name: string, colorNumber: string): string {
+  const part = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  return `${part(name)}-${part(colorNumber)}`;
+}

--- a/scripts/lib/color-math.ts
+++ b/scripts/lib/color-math.ts
@@ -1,0 +1,126 @@
+/**
+ * Color math shared by import scripts. These are exact copies of the
+ * functions in scripts/import-colors.ts — keep them in sync. (import-colors
+ * runs main() at module load, so importing from it directly isn't an option;
+ * extracting its internals wholesale is a bigger refactor than this batch
+ * needs.) Every derived value in the colors table (family, LRV, Lab) must
+ * come from these formulas or cross-brand Delta E ranking drifts.
+ */
+
+export function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): { h: number; s: number; l: number } {
+  const rr = r / 255;
+  const gg = g / 255;
+  const bb = b / 255;
+  const max = Math.max(rr, gg, bb);
+  const min = Math.min(rr, gg, bb);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rr: h = ((gg - bb) / d + (gg < bb ? 6 : 0)) / 6; break;
+      case gg: h = ((bb - rr) / d + 2) / 6; break;
+      case bb: h = ((rr - gg) / d + 4) / 6; break;
+    }
+  }
+
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+export function classifyColorFamily(r: number, g: number, b: number): string {
+  const { h, s, l } = rgbToHsl(r, g, b);
+
+  if (l > 90 && s < 15) return 'white';
+  if (l > 85 && s < 20) return 'off-white';
+  if (l < 10) return 'black';
+  if (s < 15 && l >= 10 && l <= 90) return 'gray';
+
+  if (s >= 10 && s <= 30 && h >= 30 && h <= 55 && l >= 60 && l <= 85) return 'beige';
+
+  if (s >= 15 && s <= 50 && h >= 15 && h <= 45 && l < 60) return 'brown';
+
+  if (s < 20) return 'neutral';
+
+  if (h >= 345 || h < 15) return 'red';
+  if (h >= 15 && h < 45) return 'orange';
+  if (h >= 45 && h < 70) return 'yellow';
+  if (h >= 70 && h < 170) return 'green';
+  if (h >= 170 && h < 260) return 'blue';
+  if (h >= 260 && h < 290) return 'purple';
+  if (h >= 290 && h < 345) return 'pink';
+
+  return 'neutral';
+}
+
+export function calculateLrv(r: number, g: number, b: number): number {
+  const linearize = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return (
+    0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+  ) * 100;
+}
+
+function gammaDecodeChannel(c: number): number {
+  const v = c / 255;
+  return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+function rgbToXyz(r: number, g: number, b: number): { x: number; y: number; z: number } {
+  const lr = gammaDecodeChannel(r);
+  const lg = gammaDecodeChannel(g);
+  const lb = gammaDecodeChannel(b);
+
+  const x = 0.4124564 * lr + 0.3575761 * lg + 0.1804375 * lb;
+  const y = 0.2126729 * lr + 0.7151522 * lg + 0.0721750 * lb;
+  const z = 0.0193339 * lr + 0.1191920 * lg + 0.9503041 * lb;
+
+  return { x, y, z };
+}
+
+function xyzToLab(x: number, y: number, z: number): { l: number; a: number; b: number } {
+  const xn = 0.95047;
+  const yn = 1.00000;
+  const zn = 1.08883;
+
+  const f = (t: number) => t > 0.008856 ? Math.cbrt(t) : (903.3 * t + 16) / 116;
+
+  const fx = f(x / xn);
+  const fy = f(y / yn);
+  const fz = f(z / zn);
+
+  const l = 116 * fy - 16;
+  const a = 500 * (fx - fy);
+  const b = 200 * (fy - fz);
+
+  return { l, a, b };
+}
+
+export function rgbToLab(
+  r: number,
+  g: number,
+  b: number,
+): { l: number; a: number; b_val: number } {
+  const xyz = rgbToXyz(r, g, b);
+  const lab = xyzToLab(xyz.x, xyz.y, xyz.z);
+  return {
+    l: Math.round(lab.l * 100) / 100,
+    a: Math.round(lab.a * 100) / 100,
+    b_val: Math.round(lab.b * 100) / 100,
+  };
+}
+
+export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}


### PR DESCRIPTION
## Summary
Behr's color wall loads its entire retail palette into `window.colorData` (5,692 unique colors). Our colornerd-based snapshot had drifted 1,253 colors behind — whole lines missing (PPU ×237, T ×160, ECC ×157, PPH ×148, PMD ×84, ICC ×81, plus DC/BL-W/CE and the newer A-suffix colors like Dried Rosemary S350-4A).

- `scripts/lib/color-math.ts` — shared family/LRV/Lab math (exact copies of `import-colors.ts` internals, which run `main()` on import and can't be required directly)
- `scripts/lib/behr-import-rules.ts` + tests — palette parsing (dedupes repeated classic whites), spray/gloss filter, smart title-casing, DB slug shape
- `scripts/import-behr-live.ts` — dry-run by default (`--apply` to insert); skips existing color numbers, refuses slug collisions rather than overwriting, refreshes `brands.color_count`

## Already executed against prod (2026-06-11)
- Dry run: 5,688 importable, 1,249 new, 0 slug collisions
- Applied: 1,249 inserted, Behr now 5,786 colors (DB total 24,527)
- Cross-brand match recompute running as follow-up

## Tests
`npm run test:behr-import` — 7/7 passing (filter rules, dedupe, casing, slugs, color math verified against Behr-published values for S350-4A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)