### PR TITLE
feat(data): archived colors, SW/F&B/Valspar imports, Hirshfields/Vista reconcile

### DIFF
--- a/scripts/compute-matches.ts
+++ b/scripts/compute-matches.ts
@@ -19,6 +19,7 @@ interface ProcessedColor {
   lab_b_val: number;
   lrv: number;
   color_family: string;
+  is_archived?: boolean;
   brand_slug: string;
 }
 
@@ -123,11 +124,13 @@ function main() {
     const srcIndices = brandGroups.get(srcBrand)!;
     console.log(`\nProcessing source brand: ${srcBrand} (${srcIndices.length} colors)`);
 
-    // Build list of target indices (all other brands)
+    // Build list of target indices (all other brands). Archived colors can
+    // BE matched (their pages need "closest current equivalents") but are
+    // never RECOMMENDED — nobody can buy them.
     const targetIndices: number[] = [];
     for (const [brand, indices] of brandGroups) {
       if (brand !== srcBrand) {
-        targetIndices.push(...indices);
+        targetIndices.push(...indices.filter((i) => !colors[i].is_archived));
       }
     }
 

--- a/scripts/export-db-colors.ts
+++ b/scripts/export-db-colors.ts
@@ -50,7 +50,7 @@ async function main() {
     const { data, error } = await supabase
       .from("colors")
       .select(
-        "name, slug, color_number, hex, rgb_r, rgb_g, rgb_b, lab_l, lab_a, lab_b_val, lrv, color_family, alternate_numbers, brand_id",
+        "name, slug, color_number, hex, rgb_r, rgb_g, rgb_b, lab_l, lab_a, lab_b_val, lrv, color_family, alternate_numbers, is_archived, brand_id",
       )
       .order("id", { ascending: true })
       .range(from, from + 999);

--- a/scripts/import-brand-scan.ts
+++ b/scripts/import-brand-scan.ts
@@ -45,6 +45,10 @@ interface BrandRule {
   extract: (parsed: unknown) => ScanColor[];
   /** entry-level filter; default keeps everything with a valid hex */
   keep?: (c: ScanColor) => boolean;
+  /** normalize manufacturer code to the DB color_number convention */
+  normalizeCode?: (code: string) => string;
+  /** imported rows are discontinued colors — flag is_archived */
+  archived?: boolean;
 }
 
 const BRAND_RULES: Record<string, BrandRule> = {
@@ -67,6 +71,23 @@ const BRAND_RULES: Record<string, BrandRule> = {
     extract: (p) => (p as { truly_missing: ScanColor[] }).truly_missing,
     // ES-* are exterior stains — out of scope for the wall-paint dataset.
     keep: (c) => !/^ES-/i.test(c.code),
+  },
+  // SW's live feed marks all 220 of these archived=true (Colonial Revival
+  // etc.) — discontinued colors people still search and need matches FROM.
+  'sherwin-williams': {
+    file: 'sherwin-williams-missing.json',
+    extract: (p) => p as ScanColor[],
+    archived: true,
+  },
+  'farrow-ball': {
+    file: 'farrow-ball-missing.json',
+    extract: (p) => p as ScanColor[],
+    // DB stores F&B numbers bare: "No. 300" -> "300", "No. CB1" -> "CB1"
+    normalizeCode: (code) => code.replace(/^No\.\s*/i, ''),
+  },
+  valspar: {
+    file: 'valspar-missing.json',
+    extract: (p) => p as ScanColor[],
   },
 };
 
@@ -139,7 +160,8 @@ async function importBrand(supabase: SupabaseClient, slug: string) {
   const collisions: string[] = [];
 
   for (const c of candidates) {
-    const code = c.code.toUpperCase().trim();
+    const rawCode = rule.normalizeCode ? rule.normalizeCode(c.code.trim()) : c.code.trim();
+    const code = rawCode.toUpperCase();
     if (seenCodes.has(code)) { skipped.dupInFile++; continue; }
     seenCodes.add(code);
     if (rule.keep && !rule.keep(c)) { skipped.rule++; continue; }
@@ -155,7 +177,7 @@ async function importBrand(supabase: SupabaseClient, slug: string) {
       brand_id: brand.id,
       name,
       slug: colorSlug,
-      color_number: c.code.trim(), // preserve original casing/format (e.g. "50BB 13/104")
+      color_number: rawCode, // normalized to DB convention, original casing (e.g. "50BB 13/104")
       hex: c.hex!.toLowerCase(),
       rgb_r: rgb.r,
       rgb_g: rgb.g,
@@ -165,6 +187,7 @@ async function importBrand(supabase: SupabaseClient, slug: string) {
       lab_b_val: lab.b_val,
       lrv: Math.round(calculateLrv(rgb.r, rgb.g, rgb.b) * 10) / 10,
       color_family: classifyColorFamily(rgb.r, rgb.g, rgb.b),
+      is_archived: rule.archived ?? false,
     });
   }
 
@@ -246,6 +269,52 @@ async function backfillBmAliases(supabase: SupabaseClient) {
   }
 }
 
+/**
+ * Flag existing DB rows as archived when they're absent from the brand's
+ * live palette AND present in its archive list (<brand>-archive.json).
+ * Currently used for farrow-ball (23 Archive-collection rows).
+ */
+async function flagArchived(supabase: SupabaseClient, slug: string) {
+  const rule = BRAND_RULES[slug];
+  const norm = (code: string) =>
+    (rule?.normalizeCode ? rule.normalizeCode(code.trim()) : code.trim()).toUpperCase();
+  const liveFile = path.join(SCAN_DIR, `${slug}-live.json`);
+  const archiveFile = path.join(SCAN_DIR, `${slug}-archive.json`);
+  for (const f of [liveFile, archiveFile]) {
+    if (!fs.existsSync(f)) {
+      console.error(`Required scan file not found: ${f}`);
+      process.exit(1);
+    }
+  }
+  const live = new Set(
+    (JSON.parse(fs.readFileSync(liveFile, 'utf8')) as ScanColor[]).map((c) => norm(c.code)),
+  );
+  const archive = new Set(
+    (JSON.parse(fs.readFileSync(archiveFile, 'utf8')) as { code: string }[]).map((c) => norm(c.code)),
+  );
+  const brand = await fetchBrand(supabase, slug);
+  const { aliasRows } = await fetchExisting(supabase, brand.id);
+
+  const toFlag: { id: string; number: string }[] = [];
+  let inLive = 0;
+  let notInArchive = 0;
+  for (const [number, row] of aliasRows) {
+    if (live.has(number)) { inLive++; continue; }
+    if (!archive.has(number)) { notInArchive++; console.warn(`  not live, not in archive either: ${number}`); continue; }
+    toFlag.push({ id: row.id, number });
+  }
+  console.log(`[${slug} archive flags] live-matched: ${inLive}, to flag: ${toFlag.length}, neither: ${notInArchive}`);
+  if (!APPLY) return;
+  for (const f of toFlag) {
+    const { error } = await supabase.from('colors').update({ is_archived: true }).eq('id', f.id);
+    if (error) {
+      console.error(`Flag failed for ${f.number}:`, error.message);
+      process.exit(1);
+    }
+  }
+  console.log(`  flagged ${toFlag.length} rows is_archived=true`);
+}
+
 async function main() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -265,6 +334,8 @@ async function main() {
       process.exit(1);
     }
     await backfillBmAliases(supabase);
+  } else if (process.argv.includes('--flag-archived')) {
+    await flagArchived(supabase, brandArg);
   } else {
     await importBrand(supabase, brandArg);
   }

--- a/scripts/reconcile-regional.ts
+++ b/scripts/reconcile-regional.ts
@@ -1,0 +1,274 @@
+/**
+ * Reconcile Hirshfields and Vista Paint DB rows against their live palettes
+ * (data/brand-scans/<brand>-live.json from the 2026-06 drift scan).
+ *
+ * Both brands renamed colors upstream (same supplier wave); Vista also
+ * renumbered its entire book (legacy C-470 -> live 0471, K-book scattered
+ * into the 7000/8000 series), and our Hirshfields historic rows carry
+ * name-based pseudo-codes instead of the real H0001-H0149 numbers.
+ *
+ * What this does per matched row: color_number -> live code (legacy code
+ * preserved in alternate_numbers when it was a real code), name -> live
+ * name (fixes renames, typos, mojibake). Slugs are NOT touched — URLs are
+ * stable, page copy just shows the current code/name.
+ * Unmatched live colors are imported as new rows; unmatched DB rows are
+ * reported (likely discontinued) but left alone.
+ *
+ * Usage:
+ *   tsx scripts/reconcile-regional.ts --brand=hirshfields [--apply]
+ *   tsx scripts/reconcile-regional.ts --brand=vista-paint [--apply]
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { classifyColorFamily, calculateLrv, rgbToLab, hexToRgb } from './lib/color-math';
+import { makeSlug } from './lib/behr-import-rules';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
+
+const SCAN_DIR = path.resolve(__dirname, '../data/brand-scans');
+const APPLY = process.argv.includes('--apply');
+const brandArg = process.argv.find((a) => a.startsWith('--brand='))?.split('=')[1];
+
+interface LiveColor { code: string; name: string; hex: string }
+interface DbRow {
+  id: string;
+  name: string;
+  slug: string;
+  color_number: string | null;
+  hex: string;
+  alternate_numbers: string[] | null;
+}
+
+const normName = (s: string) =>
+  s.toLowerCase().normalize('NFKD').replace(/[^a-z0-9]+/g, '');
+
+/** true when the DB code is a real manufacturer code worth preserving */
+const isRealCode = (code: string | null, brand: string) => {
+  if (!code) return false;
+  if (brand === 'hirshfields' && code.startsWith('historic-')) return false;
+  return true;
+};
+
+async function fetchRows(supabase: SupabaseClient, brandId: string): Promise<DbRow[]> {
+  const rows: DbRow[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data, error } = await supabase
+      .from('colors')
+      .select('id, name, slug, color_number, hex, alternate_numbers')
+      .eq('brand_id', brandId)
+      .order('id', { ascending: true })
+      .range(offset, offset + 999);
+    if (error) { console.error('fetch failed:', error.message); process.exit(1); }
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    offset += data.length;
+    if (data.length < 1000) break;
+  }
+  return rows;
+}
+
+function hexDist(a: string, b: string): number {
+  const ra = hexToRgb(a); const rb = hexToRgb(b);
+  if (!ra || !rb) return 999;
+  return Math.max(Math.abs(ra.r - rb.r), Math.abs(ra.g - rb.g), Math.abs(ra.b - rb.b));
+}
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) { console.error('Missing Supabase env'); process.exit(1); }
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  if (brandArg !== 'hirshfields' && brandArg !== 'vista-paint') {
+    console.error('Usage: --brand=hirshfields|vista-paint [--apply]');
+    process.exit(1);
+  }
+  const brandSlug = brandArg;
+  const live: LiveColor[] = JSON.parse(
+    fs.readFileSync(path.join(SCAN_DIR, `${brandSlug}-live.json`), 'utf8'),
+  );
+  // dedupe live by code (Vista has 2 duplicate pages)
+  const liveByCode = new Map<string, LiveColor>();
+  for (const c of live) {
+    const code = c.code.trim();
+    if (!liveByCode.has(code.toUpperCase())) liveByCode.set(code.toUpperCase(), { ...c, code });
+  }
+
+  const { data: brand } = await supabase.from('brands').select('id').eq('slug', brandSlug).single();
+  if (!brand) { console.error('brand not found'); process.exit(1); }
+  const rows = await fetchRows(supabase, brand.id);
+  console.log(`[${brandSlug}] live unique: ${liveByCode.size}, db rows: ${rows.length}`);
+
+  const matchedLive = new Set<string>(); // live code (upper)
+  const matchedDb = new Set<string>(); // row id
+  const pairs: { row: DbRow; live: LiveColor; via: string }[] = [];
+
+  const tryPair = (row: DbRow, lv: LiveColor, via: string, maxHexDist: number) => {
+    const key = lv.code.toUpperCase();
+    if (matchedDb.has(row.id) || matchedLive.has(key)) return false;
+    if (hexDist(row.hex, lv.hex) > maxHexDist) return false;
+    matchedDb.add(row.id);
+    matchedLive.add(key);
+    pairs.push({ row, live: lv, via });
+    return true;
+  };
+
+  if (brandSlug === 'hirshfields') {
+    // Numeric rows: Sku-keyed, live zero-pads ('0138' = DB '138')
+    const liveByNum = new Map<string, LiveColor>();
+    for (const lv of liveByCode.values()) {
+      if (/^\d+$/.test(lv.code)) liveByNum.set(String(parseInt(lv.code, 10)), lv);
+    }
+    for (const row of rows) {
+      const num = row.color_number ?? '';
+      if (/^\d+$/.test(num)) {
+        const lv = liveByNum.get(String(parseInt(num, 10)));
+        // generous hex tolerance: codes are authoritative for this brand
+        if (lv) tryPair(row, lv, 'sku', 999);
+      }
+    }
+  } else {
+    // Vista: legacy C-book formula — live code = C-number + 1, zero-padded 4
+    for (const row of rows) {
+      const m = /^C-(\d+)$/.exec(row.color_number ?? '');
+      if (!m) continue;
+      const lv = liveByCode.get(String(parseInt(m[1], 10) + 1).padStart(4, '0'));
+      if (lv) tryPair(row, lv, 'c-formula', 6);
+    }
+  }
+
+  // Name match for the rest
+  const liveByName = new Map<string, LiveColor[]>();
+  for (const lv of liveByCode.values()) {
+    if (matchedLive.has(lv.code.toUpperCase())) continue;
+    const k = normName(lv.name);
+    liveByName.set(k, [...(liveByName.get(k) ?? []), lv]);
+  }
+  for (const row of rows) {
+    if (matchedDb.has(row.id)) continue;
+    const cands = liveByName.get(normName(row.name)) ?? [];
+    const open = cands.filter((c) => !matchedLive.has(c.code.toUpperCase()));
+    if (open.length === 1) tryPair(row, open[0], 'name', 24);
+  }
+
+  // Hex-exact match for renamed/typo'd rows
+  const liveByHex = new Map<string, LiveColor[]>();
+  for (const lv of liveByCode.values()) {
+    if (matchedLive.has(lv.code.toUpperCase())) continue;
+    const k = lv.hex.toLowerCase();
+    liveByHex.set(k, [...(liveByHex.get(k) ?? []), lv]);
+  }
+  for (const row of rows) {
+    if (matchedDb.has(row.id)) continue;
+    const open = (liveByHex.get(row.hex.toLowerCase()) ?? []).filter(
+      (c) => !matchedLive.has(c.code.toUpperCase()),
+    );
+    if (open.length === 1) tryPair(row, open[0], 'hex', 0);
+  }
+
+  // Nearest-hex fuzzy pass: catches typo'd/mojibake/renamed rows whose hex
+  // shifted slightly between the colornerd-era data and the live site.
+  // Greedy by ascending distance, threshold 10/channel.
+  {
+    const openRows = rows.filter((r) => !matchedDb.has(r.id));
+    const openLive = [...liveByCode.values()].filter((lv) => !matchedLive.has(lv.code.toUpperCase()));
+    const cand: { d: number; row: DbRow; lv: LiveColor }[] = [];
+    for (const row of openRows) {
+      for (const lv of openLive) {
+        const d = hexDist(row.hex, lv.hex);
+        if (d <= 10) cand.push({ d, row, lv });
+      }
+    }
+    cand.sort((a, b) => a.d - b.d);
+    for (const { row, lv } of cand) tryPair(row, lv, 'near-hex', 10);
+  }
+
+  // Build updates (only where something actually changes)
+  const updates: { id: string; slug: string; via: string; set: Record<string, unknown>; from: string; to: string }[] = [];
+  for (const { row, live: lv, via } of pairs) {
+    const set: Record<string, unknown> = {};
+    if ((row.color_number ?? '') !== lv.code) {
+      set.color_number = lv.code;
+      if (isRealCode(row.color_number, brandSlug)) {
+        const alts = new Set((row.alternate_numbers ?? []).map((a) => a.toUpperCase()));
+        if (!alts.has((row.color_number as string).toUpperCase())) {
+          set.alternate_numbers = [...(row.alternate_numbers ?? []), row.color_number];
+        }
+      }
+    }
+    if (row.name !== lv.name) set.name = lv.name;
+    if (Object.keys(set).length > 0) {
+      updates.push({ id: row.id, slug: row.slug, via, set, from: `${row.color_number} ${row.name}`, to: `${lv.code} ${lv.name}` });
+    }
+  }
+
+  const unmatchedDb = rows.filter((r) => !matchedDb.has(r.id));
+  const unmatchedLive = [...liveByCode.values()].filter((lv) => !matchedLive.has(lv.code.toUpperCase()));
+  // Vista's vp-* codes are junk/duplicate site pages, not real book colors
+  const toImport = unmatchedLive.filter((lv) => !/^vp-/i.test(lv.code) && hexToRgb(lv.hex));
+
+  console.log(`matched: ${pairs.length} (${['sku', 'c-formula', 'name', 'hex', 'near-hex'].map((v) => `${v}:${pairs.filter((p) => p.via === v).length}`).join(' ')})`);
+  console.log(`updates needed: ${updates.length}`);
+  console.log(`unmatched DB rows (left alone, likely discontinued): ${unmatchedDb.length}`);
+  console.log(`unmatched live -> to import: ${toImport.length} (excluded vp-*/bad-hex: ${unmatchedLive.length - toImport.length})`);
+
+  const report = {
+    updates: updates.map((u) => ({ slug: u.slug, via: u.via, from: u.from, to: u.to })),
+    unmatched_db: unmatchedDb.map((r) => ({ code: r.color_number, name: r.name, slug: r.slug })),
+    to_import: toImport,
+  };
+  const reportFile = path.join(SCAN_DIR, `${brandSlug}-reconcile-plan.json`);
+  fs.writeFileSync(reportFile, JSON.stringify(report, null, 1));
+  console.log(`plan: ${reportFile}`);
+
+  if (!APPLY) { console.log('\nDry run — no DB changes. Re-run with --apply.'); return; }
+
+  let done = 0;
+  for (const u of updates) {
+    const { error } = await supabase.from('colors').update(u.set).eq('id', u.id);
+    if (error) { console.error(`update failed for ${u.slug}:`, error.message); process.exit(1); }
+    done++;
+    if (done % 200 === 0 || done === updates.length) console.log(`  ${done}/${updates.length} updated`);
+  }
+
+  // Import unmatched live colors
+  const existingSlugs = new Set(rows.map((r) => r.slug));
+  const inserts = [];
+  for (const lv of toImport) {
+    const rgb = hexToRgb(lv.hex)!;
+    const lab = rgbToLab(rgb.r, rgb.g, rgb.b);
+    const slug = makeSlug(lv.name, lv.code);
+    if (existingSlugs.has(slug)) { console.warn(`  slug collision, skipped: ${slug}`); continue; }
+    existingSlugs.add(slug);
+    inserts.push({
+      brand_id: brand.id,
+      name: lv.name,
+      slug,
+      color_number: lv.code,
+      hex: lv.hex.toLowerCase(),
+      rgb_r: rgb.r, rgb_g: rgb.g, rgb_b: rgb.b,
+      lab_l: lab.l, lab_a: lab.a, lab_b_val: lab.b_val,
+      lrv: Math.round(calculateLrv(rgb.r, rgb.g, rgb.b) * 10) / 10,
+      color_family: classifyColorFamily(rgb.r, rgb.g, rgb.b),
+      is_archived: false,
+    });
+  }
+  for (let i = 0; i < inserts.length; i += 500) {
+    const batch = inserts.slice(i, i + 500);
+    const { error } = await supabase.from('colors').insert(batch);
+    if (error) { console.error(`insert failed at ${i}:`, error.message); process.exit(1); }
+  }
+  console.log(`  inserted ${inserts.length} new colors`);
+
+  const { count } = await supabase.from('colors').select('*', { count: 'exact', head: true }).eq('brand_id', brand.id);
+  if (count !== null) {
+    await supabase.from('brands').update({ color_count: count }).eq('id', brand.id);
+    console.log(`  brands.color_count updated: ${count}`);
+  }
+}
+
+main().catch((err) => { console.error('Fatal error:', err); process.exit(1); });

--- a/supabase/migrations/006_archived_colors.sql
+++ b/supabase/migrations/006_archived_colors.sql
@@ -1,0 +1,8 @@
+-- Manufacturers discontinue colors but people keep searching for them — and
+-- "my color is discontinued, what's the closest current equivalent?" is the
+-- core matcher use case. Archived colors stay in the catalog as match
+-- SOURCES but are excluded as match TARGETS (compute-matches), so we never
+-- recommend a paint nobody can buy. First populated from the 2026-06 drift
+-- scan: Sherwin-Williams' 220 archived historic colors and Farrow & Ball's
+-- Archive collection.
+alter table colors add column if not exists is_archived boolean not null default false;


### PR DESCRIPTION
## Summary
Implements the remaining drift-scan decisions (MPC removal copy/redirects are in #127):

**Archived colors (migration 006)**
- `colors.is_archived boolean default false`
- Archived colors remain match *sources* (discontinued-color pages show closest current equivalents — the core matcher use case) but are excluded as match *targets* in `compute-matches`
- Populated: SW's 220 archived historic colors (imported flagged), F&B's 23 Archive-collection rows (flagged via new `--flag-archived` mode)

**Imports** — SW +220 (archived), Farrow & Ball +35, Valspar +1

**Regional reconcile (`reconcile-regional.ts`)**
- Hirshfields: real `H0001–H0149` codes replace name-based pseudo-codes; 142 upstream renames + 7 typos fixed; 1,469/1,469 rows matched
- Vista Paint: live-site renumbering applied (C-470 → 0471 formula + name/hex/near-hex passes); legacy codes preserved in `alternate_numbers`; mojibake/typo names fixed ("My Sweatheart" → "My Sweetheart"); +79 new colors; 103 likely-discontinued rows left untouched
- Slugs never change — no redirects needed

## State after applying (prod, 2026-06-11)
13 brands, **26,597 colors** (MPC's 1,419 removed). Full match recompute in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)