### PR TITLE
fix(seo): remove priceless Offer from color-page Product schema

### DIFF
--- a/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
+++ b/src/app/colors/[brandSlug]/[colorSlug]/page.tsx
@@ -627,18 +627,15 @@ export default async function ColorPage({ params }: PageProps) {
           ...(color.undertone ? [{ "@type": "PropertyValue", name: "Undertone", value: color.undertone }] : []),
           ...(color.color_family ? [{ "@type": "PropertyValue", name: "Color Family", value: color.color_family }] : []),
         ],
-        // Minimal Offer block — `price` deliberately omitted because paint
-        // pricing varies by store, region, and sheen (a wrong price triggers
-        // Google manual actions). InStoreOnly availability + named seller
-        // is enough to unlock Product rich-result eligibility across all
-        // ~23k color pages.
-        offers: {
-          "@type": "Offer",
-          availability: "https://schema.org/InStoreOnly",
-          priceCurrency: "USD",
-          seller: { "@type": "Organization", name: color.brand.name },
-          url: `https://www.paintcolorhq.com/colors/${brandSlug}/${colorSlug}`,
-        },
+        // No `offers` block: PaintColorHQ does not sell paint. A priceless
+        // Offer (priceCurrency + InStoreOnly, seller = the paint brand) pulled
+        // every color page into GSC's Merchant listings report — a shopping
+        // surface that can never validate without a real price/shipping/return
+        // policy — and marked up a buy option not visible on the page. Removed
+        // to eliminate that misrepresentation risk under the active HCU
+        // suppression. Pages remain valid Product entities (brand, color,
+        // additionalProperty, isSimilarTo). Earn Product-snippet richness only
+        // via genuine, visible review/aggregateRating on curated colors.
         ...(matches.length > 0 && {
           isSimilarTo: matches
             .filter((m) => Number(m.delta_e_score) < 2)


### PR DESCRIPTION
## What

Removes the `offers` block from the `Product` JSON-LD on color-detail pages (`/colors/[brandSlug]/[colorSlug]`).

## Why

The block emitted `priceCurrency` + `InStoreOnly` availability + `seller` (the paint brand) with **no `price`**. PaintColorHQ doesn't sell paint, so this:

- pulled all ~23K color pages into GSC's **Merchant listings** report — a shopping surface that can never validate without real price/shipping/return-policy data (perpetual warnings that never clear); and
- marked up a buy option **not visible anywhere on the page** — a latent spammy-structured-data signal, which is exactly the wrong thing to carry under the current HCU suppression.

The offer bought no real snippet richness either (no price or rating to display). Product-snippet richness should instead be earned via genuine, visible `review`/`aggregateRating` on curated colors only.

## Effect

Pages remain valid `Product` entities — `brand`, `color`, `sku`/`mpn`, `additionalProperty` (hex/RGB/LRV/undertone/family), and `isSimilarTo` are untouched. They simply drop out of the Merchant listings report.

## Verification

- `seo-preflight`: **GO** — no content/meta/link/canonical/schema-syntax regressions.
- `seo-drift` baseline **#14** captured pre-deploy (live page *with* the Offer). Post-deploy, run:
  ```
  python3 scripts/drift/drift_compare.py "https://www.paintcolorhq.com/colors/sherwin-williams/agreeable-gray-7029"
  ```
  Expected: **R08 (CRITICAL)** firing on `Offer`/`Organization` removal only — that's the intended delta. Any *other* finding = unintended regression.
- GSC Merchant listings report should clear over the following weeks (re-processing lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)